### PR TITLE
Fix marketplace name casing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "posthog-skills",
+  "name": "PostHog-skills",
   "owner": {
     "name": "PostHog"
   },

--- a/scripts/generate-marketplace.sh
+++ b/scripts/generate-marketplace.sh
@@ -45,7 +45,7 @@ mkdir -p .claude-plugin
 jq -n \
   --argjson plugins "$PLUGINS_JSON" \
   '{
-    name: "posthog-skills",
+    name: "PostHog-skills",
     owner: { name: "PostHog" },
     metadata: {
       description: "PostHog skills for Claude Code — analytics, feature flags, error tracking, and more"


### PR DESCRIPTION
## Summary
- Changes marketplace name from `posthog-skills` to `PostHog-skills` in both `marketplace.json` and the discovery script

## Why
Claude Code clones to `PostHog-skills` (preserving GitHub owner case) then tries to rename to `posthog-skills` (lowercased marketplace name). On macOS case-insensitive filesystems, these resolve to the same path and the rename fails with ENOENT.

## Test plan
- [ ] `rm -rf ~/.claude/plugins/marketplaces/posthog-skills ~/.claude/plugins/marketplaces/PostHog-skills`
- [ ] `/plugin marketplace add PostHog/skills` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)