### PR TITLE
chore(phai): request team-posthog-ai review on omnibus sync PRs

### DIFF
--- a/.github/workflows/sync-omnibus.yml
+++ b/.github/workflows/sync-omnibus.yml
@@ -138,5 +138,6 @@ jobs:
             --base "$BASE_REF" \
             --head "$HEAD_REF" \
             --title "$COMMIT_MESSAGE" \
-            --body "Automated skill sync from PostHog release and context-mill.")
+            --body "Automated skill sync from PostHog release and context-mill." \
+            --reviewer "PostHog/team-posthog-ai")
           gh pr merge "$PR_URL" --auto --squash


### PR DESCRIPTION
## Problem

Automated omnibus sync PRs weren't requesting reviewers, so they sat without a clear owner to review.

## Changes

Pass `--reviewer PostHog/team-posthog-ai` to `gh pr create` in the sync-omnibus workflow.

## How did you test this code?

Static change only — will be exercised on the next scheduled sync run (or via `workflow_dispatch`).

## Publish to changelog?

no