### PR TITLE
feat(pr-retro-skill): add skill for an PR-based sprint-review

### DIFF
--- a/skills/team/engineering/weekly-pr-retrospective/.claude-plugin/plugin.json
+++ b/skills/team/engineering/weekly-pr-retrospective/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "weekly-pr-retrospective",
+  "description": "Weekly PR retrospective categorized against goals from a user-provided source (GitHub issue or website)",
+  "version": "1.0.0",
+  "author": { "name": "PostHog" },
+  "keywords": ["posthog", "engineering", "retrospective", "github", "pr-review"]
+}

--- a/skills/team/engineering/weekly-pr-retrospective/README.md
+++ b/skills/team/engineering/weekly-pr-retrospective/README.md
@@ -1,0 +1,81 @@
+# Weekly PR retrospective
+
+A Claude skill that produces a categorized weekly PR retrospective for an engineer or a small team, mapping each PR to a goal/objective defined in a source you set up once (a GitHub issue or a public web page).
+
+## What it does
+
+- Fetches your last 7 days of PRs across the PostHog GitHub org.
+- Pulls a list of goals/objectives from a source you configured during setup.
+- Categorizes each PR against those goals and tags it with a meta-label (`feature`, `maintenance`, `bug`, `incident`, `infra`, `docs`, `test`, `chore`).
+- Writes a markdown report to `~/Development/<year-week>/pr-retrospective-<scope>-YYYY-MM-DD.md` and links to it.
+
+## Requirements
+
+- `gh` CLI installed and authenticated (`gh auth login`).
+- For team mode: read access to the relevant PostHog repos via your `gh` auth.
+- For website goal sources: outbound HTTPS access (the skill uses `WebFetch`).
+
+## First-run setup
+
+The first time you invoke the skill (or any time `~/.config/weekly-pr-retrospective/config.json` is missing), it walks you through a one-time setup:
+
+1. **Goals source** — paste either:
+   - A GitHub issue shorthand: `owner/repo#NUM` (e.g. `acme/infra#42`)
+   - A GitHub issue URL: `https://github.com/<owner>/<repo>/issues/<num>`
+   - Any public `https://` URL pointing to a page that lists goals (e.g. a Notion public page, a docs page)
+2. **Team handles** — comma-separated list of GitHub handles to include in `team` mode (no `@`). You can leave it blank if you only ever want single-user mode.
+
+The answers are written to `~/.config/weekly-pr-retrospective/config.json`. Subsequent invocations skip the setup step entirely.
+
+To re-run setup later (e.g. to point at a new goals source or update team handles):
+
+```text
+/weekly-pr-retrospective setup
+```
+
+### Config file schema
+
+```json
+{
+  "goals_source": "acme/infra#42",
+  "team": ["alice", "bob", "carol"]
+}
+```
+
+## Usage
+
+```text
+/weekly-pr-retrospective           # single-user mode (just you)
+/weekly-pr-retrospective team      # team mode (you + saved team handles)
+/weekly-pr-retrospective setup     # re-run the one-time setup flow
+```
+
+## Modes
+
+- **Single-user (default)** — covers only the PRs you (the invoking user, resolved via `gh api user`) opened in the last 7 days.
+- **Team** — adds the saved team handles from the config file and includes a per-author breakdown.
+
+## Output
+
+The report file lands at:
+
+```text
+~/Development/<ISO-year-week>/pr-retrospective-<user|team>-YYYY-MM-DD.md
+```
+
+It contains:
+
+- Header with mode, authors, date range, PR count, and the goals source used.
+- One section per goal pulled from the source, listing matching PRs.
+- Sensibly-named "Other" sections for PRs that don't map to any listed goal.
+- Summary counts (per goal, per meta-tag, and per author in team mode).
+
+## Files
+
+```text
+weekly-pr-retrospective/
+├── README.md              # This file
+├── SKILL.md               # Main skill instructions
+└── .claude-plugin/
+    └── plugin.json        # Plugin metadata (auto-discovered by the marketplace)
+```

--- a/skills/team/engineering/weekly-pr-retrospective/SKILL.md
+++ b/skills/team/engineering/weekly-pr-retrospective/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: weekly-pr-retrospective
+description: Weekly PR retrospective for an engineer or team, categorized against goals defined in a source (GitHub issue or website). On first run it walks the user through a one-time setup that persists their goals source and team-member list to a config file. Run locally where `gh` is authenticated.
+---
+
+Produce a weekly PR retrospective covering the last 7 days of GitHub activity, categorized against a list of goals/objectives stored in a per-user config file.
+
+## Configuration file
+
+This skill is driven by a config file at:
+
+```
+~/.config/weekly-pr-retrospective/config.json
+```
+
+Schema:
+
+```json
+{
+  "goals_source": "<github-issue-shorthand-or-url-or-website-url>",
+  "team": ["handle1", "handle2", "..."]
+}
+```
+
+- `goals_source` — required. One of:
+  - A GitHub issue shorthand: `owner/repo#NUM` (e.g. `acme/infra#42`)
+  - A GitHub issue URL: `https://github.com/<owner>/<repo>/issues/<num>`
+  - Any other `https://` URL pointing to a public web page that lists goals
+- `team` — required (can be an empty array). The list of GitHub handles whose PRs are pulled in **team mode**. The invoking user is resolved separately and unioned in at runtime, so omit yourself.
+
+## Arguments
+
+This command takes one optional argument:
+
+- _no argument_ → **single-user mode**: report only on the invoking user's PRs.
+- `team` → **team mode**: include the saved `team` handles from the config file in addition to the invoking user.
+- `setup` → force re-run the setup flow even if the config file already exists.
+
+Treat any other argument as invalid and ask the user to clarify.
+
+## Steps
+
+### Step 0 — Setup (only when needed)
+
+1. Check whether `~/.config/weekly-pr-retrospective/config.json` exists.
+2. **Skip the rest of this step entirely if the file exists** and the user did not pass `setup`. Read the file and proceed to Step 1.
+3. If the file is missing, or the user passed `setup`, run the setup flow:
+   - Ask the user, exactly: _"What's the source of your goals? Paste a GitHub issue (`owner/repo#NUM` or a `https://github.com/.../issues/NUM` URL) or a public `https://` website URL."_
+   - Validate the answer matches one of the three accepted shapes. If not, ask again. Do not invent or default a value.
+   - Ask the user, exactly: _"Which GitHub handles should `team` mode include? Comma-separated list, no `@`. Leave blank if you only want single-user mode."_
+   - Parse into an array of handles, trimmed, lowercased only if the user wrote them lowercased — keep their original casing otherwise. Empty input → empty array.
+   - Ensure `~/.config/weekly-pr-retrospective/` exists, then write the config file as pretty-printed JSON.
+   - Confirm in chat: "Saved config to `~/.config/weekly-pr-retrospective/config.json`. You can re-run setup any time with `/weekly-pr-retrospective setup`."
+
+After setup, continue to Step 1 with the freshly-saved values.
+
+### Step 1 — Validate the loaded config
+
+- `goals_source` must be present and match one of: `owner/repo#NUM`, GitHub issue URL, or a generic `https://` URL. If it doesn't, prompt the user to re-run setup (`/weekly-pr-retrospective setup`) and stop.
+- `team` must be an array (possibly empty). If the user invoked `team` mode and the array is empty, tell them they need to re-run setup to add team handles, and stop.
+
+### Step 2 — Identify the invoking user
+
+Run `gh api user --jq .login` via Bash. If `gh` is not authenticated, stop and tell the user to run `gh auth login`.
+
+### Step 3 — Resolve the author list
+
+- Single-user mode: `authors = [<invoking user>]`.
+- Team mode: `authors = unique([<invoking user>, ...config.team])`. Deduplicate so the invoking user isn't double-counted if already listed in `team`.
+
+### Step 4 — Fetch the goals from `goals_source`
+
+- **GitHub issue shorthand** (`owner/repo#NUM`): run `gh issue view <NUM> --repo <owner>/<repo> --json title,body,labels`.
+- **GitHub issue URL**: parse out `<owner>`, `<repo>`, and `<num>`, then run the same `gh issue view ...` command.
+- **Generic web URL**: use the WebFetch tool to retrieve the page contents. Prompt WebFetch to extract the list of goals/objectives/initiatives from the page.
+
+Parse the result and extract the listed goals. Treat each distinct goal/bullet as a target category. Keep the original goal phrasing so categories are recognizable.
+
+If the source can't be fetched (404, private, network error), report that and ask the user whether to re-run setup with a different source. Do not proceed with a guessed category list.
+
+### Step 5 — Fetch each author's PRs from the last 7 days
+
+Scope to the PostHog org (no per-repo filter — we want every PR the author opened anywhere in PostHog/*). For each author, run:
+
+```
+gh search prs --author "<login>" --owner PostHog --created ">=$(date -v-7d +%Y-%m-%d 2>/dev/null || date -d '7 days ago' +%Y-%m-%d)" --limit 100 --json number,title,url,repository,state,createdAt,closedAt,body,labels
+```
+
+Include both open and closed/merged PRs. If `--created` filter doesn't return enough, fall back to `gh search prs --author "<login>" --owner PostHog --limit 200 --json ...` and filter client-side by `createdAt` within the last 7 days. Tag each PR result with its author so authorship is preserved when the lists are merged.
+
+Note: do **not** include `mergedAt` in `--json` — `gh search prs` doesn't expose that field. State (`merged`/`closed`/`open`) plus `closedAt` is enough.
+
+### Step 6 — Categorize each PR
+
+For each PR:
+- Read its title, body, labels, and repo.
+- Decide which goal from the fetched goals list it maps to. A PR can map to one primary goal (pick the best fit). If it doesn't fit any listed goal, place it in a sensibly-named "Other" group (e.g., "Developer experience", "Tooling", "Documentation") — name groups so they're useful, not generic.
+- Tag each PR with one or more meta labels from this set: `feature` (new user-facing capability), `maintenance` (keep-the-lights-on, refactors, deps, cleanup), `test` (test-only changes), `incident` (incident response or hotfix), `bug` (bug fix not tied to incident), `infra` (infrastructure/IaC), `docs`, `chore`. Use PR labels and content to infer; pick the most fitting tags.
+
+### Step 7 — Write the report
+
+Resolve the current ISO year-week with `date +"%G-W%V"` (e.g. `2026-W17`). Ensure `~/Development/<year-week>/` exists (create it if needed), then write the markdown file to `~/Development/<year-week>/pr-retrospective-<scope>-YYYY-MM-DD.md`, where `<scope>` is `user` in single-user mode or `team` in team mode. Use today's date for `YYYY-MM-DD`.
+
+Structure:
+- Header with mode (single-user vs. team), the list of authors covered, the date range, total PR count, and the goals source used (issue ref or URL).
+- One section per goal from the fetched goals source, listing matching PRs as:
+  - Single-user mode: `- [#NUM repo/name](url) — title  ·  *meta-tags*`
+  - Team mode: `- [#NUM repo/name](url) — title  ·  *@author*  ·  *meta-tags*` (author shown so the reader can tell who shipped what)
+  Add a one-line "what it did" summary if non-obvious.
+- Sections for any "Other" groups you defined, named meaningfully.
+- Summary at the bottom:
+  - Counts per goal.
+  - Counts per meta tag.
+  - **Team mode only:** counts per author (PRs shipped per person, plus a per-author goal breakdown — useful for spotting whether someone landed work outside their owned goal).
+  - Any goals with zero PRs this week.
+- Note any PRs that were ambiguous to categorize.
+
+### Step 8 — Share the file
+
+End with a `[View your retrospective](computer://...)` link to the file. Keep the chat response brief — the file is the deliverable.
+
+## Constraints
+
+- Use the `gh` CLI for all GitHub access; do not call the GitHub API via curl/python.
+- Do not hardcode the invoking user's GitHub username — always resolve it from `gh api user`.
+- Never default the goals source. It must come from the config file (or be set via setup).
+- Never auto-rewrite the config file in the course of a normal run. The config is only written by the setup flow.
+- If the goals source cannot be fetched (renamed, private, deleted, network error), report that and offer to re-run setup — do not silently fall back to inferred themes.
+- If there are zero PRs in the last 7 days for the chosen scope, still produce the report saying so.
+- In team mode, paginate carefully if any one author exceeds the `--limit 100` window — but 100 PRs/week/person is unrealistic, so prefer a single fetch per author and only fall back to client-side filtering if a fetch returns ≥100 items.

--- a/skills/team/engineering/weekly-pr-retrospective/SKILL.md
+++ b/skills/team/engineering/weekly-pr-retrospective/SKILL.md
@@ -127,4 +127,4 @@ End with a `[View your retrospective](computer://...)` link to the file. Keep th
 - Never auto-rewrite the config file in the course of a normal run. The config is only written by the setup flow.
 - If the goals source cannot be fetched (renamed, private, deleted, network error), report that and offer to re-run setup — do not silently fall back to inferred themes.
 - If there are zero PRs in the last 7 days for the chosen scope, still produce the report saying so.
-- In team mode, paginate carefully if any one author exceeds the `--limit 100` window — but 100 PRs/week/person is unrealistic, so prefer a single fetch per author and only fall back to client-side filtering if a fetch returns ≥100 items.
+- In team mode, paginate carefully if any one author exceeds the `--limit 100` window — but 100 PRs/week/person can happen though, so prefer a single fetch per author and only fall back to client-side filtering if a fetch returns ≥100 items.

--- a/skills/team/engineering/weekly-pr-retrospective/SKILL.md
+++ b/skills/team/engineering/weekly-pr-retrospective/SKILL.md
@@ -100,6 +100,7 @@ For each PR:
 ### Step 7 — Write the report
 
 Resolve the current ISO year-week with `date +"%G-W%V"` (e.g. `2026-W17`). Ensure `~/Development/<year-week>/` exists (create it if needed), then write the markdown file to `~/Development/<year-week>/pr-retrospective-<scope>-YYYY-MM-DD.md`, where `<scope>` is `user` in single-user mode or `team` in team mode. Use today's date for `YYYY-MM-DD`.
+Important: do not blame any of the team mates, this report is solely for ease of use and creating transparency for asking the right questions and not intended as any kind of performance report. 
 
 Structure:
 - Header with mode (single-user vs. team), the list of authors covered, the date range, total PR count, and the goals source used (issue ref or URL).


### PR DESCRIPTION
Adding a skill that fetches all PRs of a list of gh users (your team 😅 ) and groups them to a list of goals that you have either defined in a gh issue or public website. 

The skill groups the PRs to the goals and adds a section of observations (e.g. "so many PRs are not aligned to any goal").
