### PR TITLE
fix: prune orphan skill dirs in omnibus sync workflow

### DIFF
--- a/.github/workflows/sync-omnibus.yml
+++ b/.github/workflows/sync-omnibus.yml
@@ -78,6 +78,14 @@ jobs:
           } | sort -u > "$MANIFEST"
           rm -f "$cm_manifest"
 
+          # Reconcile: remove any directory not in the new manifest
+          # (catches orphans from past manual edits or partial deletions)
+          for d in skills/omnibus/*/; do
+            [ -d "$d" ] || continue
+            name=$(basename "$d")
+            grep -qFx "$name" "$MANIFEST" || rm -rf "$d"
+          done
+
       - name: Check for changes
         id: check
         env:


### PR DESCRIPTION
## Problem

The omnibus sync workflow only deletes skill directories listed in the OLD manifest before re-extracting upstream zips. Anything in `skills/omnibus/` that isn't in the manifest — orphans from past manual edits, partial deletions, or pre-manifest history — sticks around forever.

This is the same gap recently fixed in PostHog/ai-plugin#54. Porting it here.

## Changes

After rebuilding the manifest, walk `skills/omnibus/*/` and remove any directory not present in the new manifest. The directory-only glob (`*/`) leaves files like `README.md` untouched. Extraction happens first, so anything actually shipped by the upstream zips ends up in the manifest and survives the prune.

## How did you test this code?

Validated the equivalent fix in ai-plugin by running the sync logic locally against a planted orphan dir and a real upstream rename (`query-examples` → `querying-posthog-data`); both got reconciled correctly. Ran a dry-run of the reconcile glob against the current `skills/omnibus/` state in this repo — no directories would be pruned (`README.md` is a file and is correctly skipped).

## Publish to changelog?

no