### PR TITLE
chore: pin github actions to commit shas

### DIFF
--- a/.github/workflows/generate-marketplace.yml
+++ b/.github/workflows/generate-marketplace.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Discover plugins and generate marketplace.json
         run: ./scripts/generate-marketplace.sh


### PR DESCRIPTION
Pins actions in .github/workflows to commit SHAs via pinact. Generated by multi-gitter.