### PR TITLE
chore(marketplace): register impersonation-toolkit in catalog

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,6 +8,18 @@
   },
   "plugins": [
     {
+      "name": "impersonation-toolkit",
+      "source": "./skills/team/customer-success/impersonation-toolkit",
+      "description": "Run safer impersonation-scoped audits against a customer's PostHog project via Claude Code + the PostHog MCP plugin. Read-only by default; prompts before any mutative MCP call.",
+      "keywords": [
+        "posthog",
+        "impersonation",
+        "audit",
+        "customer-success",
+        "experiments"
+      ]
+    },
+    {
       "name": "posthog-debugger",
       "source": "./skills/team/customer-success/posthog-debugger",
       "description": "Debug and inspect PostHog implementations on any website",


### PR DESCRIPTION
## Summary

Adds the \`impersonation-toolkit\` entry to \`marketplace.json\` so the plugin is discoverable via \`/plugin install impersonation-toolkit@PostHog-skills\`.

## Context

The plugin itself landed in #76 at \`skills/team/customer-success/impersonation-toolkit/\` and is fully functional. But \`marketplace.json\` wasn't regenerated on merge, so Claude Code's marketplace lookup returns \`Plugin not found in marketplace\` when teammates try to install it. This PR fixes that.

I noticed the catalog has broader drift — running \`./scripts/generate-marketplace.sh\` would discover 8 plugins missing from the catalog (including a couple where source paths were renamed in the repo but the old paths persist in the catalog). I deliberately did *not* include those fixes in this PR to keep the diff scoped and avoid stepping on other teams' work. Worth a separate full-regen PR by whoever owns marketplace upkeep.

## Test plan

After merge:
- [ ] \`claude plugin marketplace update PostHog-skills\` refreshes the cache
- [ ] \`claude plugin install impersonation-toolkit@PostHog-skills\` succeeds