### PR TITLE
fix(impersonation-toolkit): tighten security per review — read-only impersonation default + execute-sql/*-create to ask

### DIFF
--- a/skills/team/customer-success/impersonation-toolkit/README.md
+++ b/skills/team/customer-success/impersonation-toolkit/README.md
@@ -52,21 +52,29 @@ impersonate-audit givebutter
 The script will:
 
 1. Create (or reuse) `~/impersonate/<customer-slug>/` and refresh the permissions config from the plugin's template
-2. Pause and remind you to impersonate the customer's user in Django Admin (manual step — pick read+write)
+2. Pause and remind you to impersonate the customer's user in Django Admin (manual step — pick **read-only** by default; only pick read+write if you'll actually need to create something in the customer's account during the audit, e.g. an example experiment or dashboard)
 3. Launch Claude Code in the folder
 4. Inside Claude Code: run `/mcp`, find the `posthog` plugin, **clear authentication** then **authenticate** — this binds a fresh token from your active impersonation session
 5. Sanity check by asking Claude `what project am I in?` — should be the customer's project, not yours
 6. Run the audit by asking e.g. `audit <customer>'s experiment named "<experiment name>"` — the `experiment-audit` skill auto-triggers
 7. On exit, the script auto-disables the posthog plugin if it's still connected and reminds you to log out of Django Admin
 
-## How permissions work
+## Security model
 
-`assets/settings.local.json` is copied into every customer folder on each run as `.claude/settings.local.json`. It defines two lists:
+The toolkit relies on two independent layers of defense — both have to fail for an unwanted mutation to land in a customer's account:
 
-- **`allow`** — auto-approved patterns (reads + safe creates). No prompts.
-- **`ask`** — patterns that always prompt for explicit confirmation (updates, deletes, archives, plus specific destructive `*-create` tools the PostHog MCP exposes).
+1. **Impersonation token scope (server-side).** When you impersonate a user in Django Admin and select **read-only**, PostHog's OAuth authorization server downgrades every `:write` scope to `:read` before minting the access token. Even if a client requests broad scopes, the resulting token literally cannot write. This is enforced server-side, not by the client. Default to read-only impersonation; only escalate to read+write when you need to create something in the customer's account.
 
-Updates to the template ship via `claude plugin update`.
+2. **Claude Code permission rules (client-side).** `assets/settings.local.json` is copied into every customer folder on each run as `.claude/settings.local.json`. It defines two lists:
+
+   - **`allow`** — auto-approved patterns. Reads (list/get/retrieve/search/query/execute-sql/stats/etc.) **and creates** (`*-create`, `create-*`). We allow creates so you can spin up example experiments / dashboards / surveys in the customer's account during an audit walkthrough without clicking through prompts. The skill itself is read-only by design — creates are user-driven, not skill-driven.
+   - **`ask`** — patterns that always prompt for explicit confirmation: updates, deletes, archives, plus 7 specific exact-name overrides for destructive `*-create` tools that the broad pattern doesn't catch (e.g. `feature-flags-bulk-delete-create`).
+
+   Anything not matched by either list falls through to Claude Code's default behavior (prompt).
+
+The combination means: even if you forget to switch impersonation to read-only, mutative operations still surface as a prompt before they fire. And even if a tool slips through the prompt logic, a read-only token rejects it server-side.
+
+Updates to the permission template ship via `claude plugin update`.
 
 ## Updating
 

--- a/skills/team/customer-success/impersonation-toolkit/README.md
+++ b/skills/team/customer-success/impersonation-toolkit/README.md
@@ -67,12 +67,12 @@ The toolkit relies on two independent layers of defense — both have to fail fo
 
 2. **Claude Code permission rules (client-side).** `assets/settings.local.json` is copied into every customer folder on each run as `.claude/settings.local.json`. It defines two lists:
 
-   - **`allow`** — auto-approved patterns. Reads (list/get/retrieve/search/query/execute-sql/stats/etc.) **and creates** (`*-create`, `create-*`). We allow creates so you can spin up example experiments / dashboards / surveys in the customer's account during an audit walkthrough without clicking through prompts. The skill itself is read-only by design — creates are user-driven, not skill-driven.
-   - **`ask`** — patterns that always prompt for explicit confirmation: updates, deletes, archives, plus 7 specific exact-name overrides for destructive `*-create` tools that the broad pattern doesn't catch (e.g. `feature-flags-bulk-delete-create`).
+   - **`allow`** — auto-approved patterns. Strictly reads — list/get/retrieve/search/query/stats/counts/etc.
+   - **`ask`** — patterns that always prompt for explicit confirmation: updates, deletes, archives, creates (`*-create`, `create-*`), and `execute-sql`. The skill itself is read-only by design — creates and SQL are user-driven (e.g. spinning up an example experiment during a demo, or running an ad-hoc HogQL query), and require an explicit one-click approval each time. 7 specific exact-name overrides for destructive `*-create` tools (e.g. `feature-flags-bulk-delete-create`) remain even though the broad `*-create` pattern now covers them — they serve as documentation of the known-destructive set.
 
    Anything not matched by either list falls through to Claude Code's default behavior (prompt).
 
-The combination means: even if you forget to switch impersonation to read-only, mutative operations still surface as a prompt before they fire. And even if a tool slips through the prompt logic, a read-only token rejects it server-side.
+The combination means: every mutative operation surfaces as a prompt before it fires (client-side defense), AND if a tool somehow slipped through, the read-only impersonation token rejects the write at the API layer (server-side defense). Both have to fail for an unwanted change to land.
 
 Updates to the permission template ship via `claude plugin update`.
 

--- a/skills/team/customer-success/impersonation-toolkit/assets/settings.local.json
+++ b/skills/team/customer-success/impersonation-toolkit/assets/settings.local.json
@@ -9,7 +9,6 @@
       "mcp__plugin_posthog_posthog__*-search",
       "mcp__plugin_posthog_posthog__query-*",
       "mcp__plugin_posthog_posthog__read-*",
-      "mcp__plugin_posthog_posthog__execute-sql",
       "mcp__plugin_posthog_posthog__*-stats",
       "mcp__plugin_posthog_posthog__*-counts",
       "mcp__plugin_posthog_posthog__*-count",
@@ -39,11 +38,12 @@
       "mcp__plugin_posthog_posthog__agent-feedback",
       "mcp__plugin_posthog_posthog__web-analytics-weekly-digest",
       "mcp__plugin_posthog_posthog__get-llm-total-costs-for-project",
-      "mcp__plugin_posthog_posthog__llma-personal-spend",
-      "mcp__plugin_posthog_posthog__*-create",
-      "mcp__plugin_posthog_posthog__create-*"
+      "mcp__plugin_posthog_posthog__llma-personal-spend"
     ],
     "ask": [
+      "mcp__plugin_posthog_posthog__execute-sql",
+      "mcp__plugin_posthog_posthog__*-create",
+      "mcp__plugin_posthog_posthog__create-*",
       "mcp__plugin_posthog_posthog__*-update",
       "mcp__plugin_posthog_posthog__*-update-*",
       "mcp__plugin_posthog_posthog__*-partial-update",

--- a/skills/team/customer-success/impersonation-toolkit/scripts/impersonate-audit.sh
+++ b/skills/team/customer-success/impersonation-toolkit/scripts/impersonate-audit.sh
@@ -57,7 +57,10 @@ cat <<EOF
 
 STEP 1: Impersonate the customer's user in Django Admin
   - Open PostHog Django Admin in your browser
-  - Find the user → click "Impersonate" → select read+write scope
+  - Find the user → click "Impersonate" → select read-only scope
+    (read+write is only needed if you'll create something in their account
+    during the audit — e.g. an example experiment or dashboard. Default
+    to read-only.)
   - Keep that browser tab open through the whole audit
 
 EOF


### PR DESCRIPTION
## Summary

Addresses the two issues raised by Felipe Aragão in security review:

1. **Impersonation token scope** ([flagged line](https://github.com/PostHog/skills/blob/3b62016a9f5e6b30322c64434d4c29b3667e15bd/skills/team/customer-success/impersonation-toolkit/scripts/impersonate-audit.sh#L60)) — the script was telling users to pick \`read+write\` when impersonating. The original install path used \`npx @posthog/wizard\`, which rejected read-only impersonation with \`invalid_scope\`, and the README/script prompt carried that old guidance forward.

   PostHog's OAuth \`/authorize\` endpoint already handles read-only impersonation correctly via [\`downgrade_scopes_to_read_only\`](https://github.com/PostHog/posthog/blob/master/posthog/scopes.py) (called from \`posthog/api/oauth/views.py\`): when the impersonating session is read-only, every requested \`:write\` scope is downgraded to \`:read\` server-side before minting the token. So the \`/mcp\` re-auth flow accepts read-only without issue — the original blocker was wizard-specific.

   **Changes:** README + script prompt now recommend read-only impersonation by default. Only escalate to read+write when you'll actually create something in the customer's account during the audit.

2. **\`*-create\`, \`create-*\`, and \`execute-sql\` in \`allow\`** ([flagged lines](https://github.com/PostHog/skills/blob/main/skills/team/customer-success/impersonation-toolkit/assets/settings.local.json#L43-L44)) — these patterns auto-approved any create operation or HogQL query without prompting. The original rationale was \"creates are user-driven during demos / training, so we shouldn't friction them.\" Moving them to \`ask\` is a one-click cost per use in exchange for closing the auto-approve surface entirely on mutative or sensitive operations.

   **Changes:** \`execute-sql\`, \`*-create\`, and \`create-*\` moved from \`allow\` → \`ask\`. The 7 exact-name overrides for destructive \`*-create\` tools (\`feature-flags-bulk-delete-create\`, \`error-tracking-issues-merge-create\`, etc.) are now redundant since \`*-create\` itself is in \`ask\`, but kept as documentation of the known-destructive set.

Also adds a **Security model** section to the plugin README that explicitly documents the two layered defenses (server-side token scope + client-side permission rules) so future contributors understand why each rule exists.

## Test plan

- [ ] Live verification: run an audit with read-only impersonation through the \`/mcp\` re-auth flow and confirm the OAuth handshake succeeds
- [ ] Confirm \`execute-sql\` and any \`-create\` call surfaces a prompt in Claude Code
- [ ] README renders correctly on GitHub with the new Security model section