### PR TITLE
chore(impersonation-toolkit): bump version to 1.0.1

### DIFF
--- a/skills/team/customer-success/impersonation-toolkit/.claude-plugin/plugin.json
+++ b/skills/team/customer-success/impersonation-toolkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "impersonation-toolkit",
   "description": "Run safer impersonation-scoped audits against a customer's PostHog project via Claude Code + the PostHog MCP plugin. Read-only by default; prompts before any mutative MCP call. Includes a shell wrapper for setting up impersonation folders and a permissions template that scopes each session.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": { "name": "PostHog" },
   "keywords": ["posthog", "impersonation", "audit", "customer-success", "experiments"]
 }


### PR DESCRIPTION
## Summary
- Bump `impersonation-toolkit` plugin version from `1.0.0` to `1.0.1`
- Forces `claude plugin update` to pull the security-hardening changes from #82

## Why
Without a version bump, `claude plugin update impersonation-toolkit@PostHog-skills` reports "already at the latest version (1.0.0)" and silently keeps the stale template — teammates who installed before #82 merged would remain on the pre-hardening rules without realizing it.

## Test plan
- [ ] After merge, run `claude plugin marketplace update PostHog-skills && claude plugin update impersonation-toolkit@PostHog-skills` on a machine that has the old install — confirm it actually pulls and the cache reflects `1.0.1`