### PR TITLE
chore: migrate client getFeatureFlagPayload examples to getFeatureFlagResult

### DIFF
--- a/skills/omnibus/instrument-feature-flags/references/adding-feature-flag-code.md
+++ b/skills/omnibus/instrument-feature-flags/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1648,7 +1648,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1859,7 +1859,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -1874,7 +1874,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -1935,7 +1935,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -1949,7 +1949,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2028,7 +2028,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2042,7 +2042,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/omnibus/instrument-feature-flags/references/android.md
+++ b/skills/omnibus/instrument-feature-flags/references/android.md
@@ -88,7 +88,7 @@
     if (isMyFlagEnabled) {
         // Do something differently for this user
         // Optional: fetch the payload
-        val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+        val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
     }
     ```
 
@@ -109,7 +109,7 @@
     if (enabledVariant == "variant-key") { // replace 'variant-key' with the key of your variant
         // Do something differently for this user
         // Optional: fetch the payload
-        val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+        val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
     }
     ```
 

--- a/skills/omnibus/instrument-feature-flags/references/flutter.md
+++ b/skills/omnibus/instrument-feature-flags/references/flutter.md
@@ -154,7 +154,7 @@
     if (isMyFlagEnabled) {
         // Do something differently for this user
         // Optional: fetch the payload
-        final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+        final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
     }
     ```
 
@@ -175,7 +175,7 @@
     if (enabledVariant == 'variant-key') { // replace 'variant-key' with the key of your variant
         // Do something differently for this user
         // Optional: fetch the payload
-        final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+        final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
     }
     ```
 

--- a/skills/omnibus/instrument-feature-flags/references/ios.md
+++ b/skills/omnibus/instrument-feature-flags/references/ios.md
@@ -88,7 +88,7 @@
     if isMyFlagEnabled {
         // Do something differently for this user
         // Optional: fetch the payload
-        let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+        let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
     }
     ```
 
@@ -109,7 +109,7 @@
     if enabledVariant == "variant-key" { // replace 'variant-key' with the key of your variant
         // Do something differently for this user
         // Optional: fetch the payload
-        let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+        let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
     }
     ```
 

--- a/skills/omnibus/instrument-feature-flags/references/react-native.md
+++ b/skills/omnibus/instrument-feature-flags/references/react-native.md
@@ -105,7 +105,7 @@
         if (isMyFlagEnabled) {
             // Do something differently for this user
             // Optional: fetch the payload
-            const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+            const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
         }
         return <View>...</View>
     }
@@ -127,7 +127,7 @@
         if (enabledVariant === 'variant-key') { // replace 'variant-key' with the key of your variant
             // Do something differently for this user
             // Optional: fetch the payload
-            const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+            const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
         }
         return <View>...</View>
     }

--- a/skills/omnibus/instrument-feature-flags/references/usage.md
+++ b/skills/omnibus/instrument-feature-flags/references/usage.md
@@ -482,7 +482,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -496,7 +496,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 

--- a/skills/omnibus/instrument-feature-flags/references/web.md
+++ b/skills/omnibus/instrument-feature-flags/references/web.md
@@ -94,7 +94,7 @@
     if (posthog.isFeatureEnabled('flag-key')) {
         // Do something differently for this user
         // Optional: fetch the payload
-        const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+        const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
     }
     ```
 
@@ -110,7 +110,7 @@
     if (posthog.getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
         // Do something differently for this user
         // Optional: fetch the payload
-        const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+        const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
     }
     ```
 
@@ -123,7 +123,7 @@
     Feature flags can include payloads with additional data. Fetch the payload like this:
 
     ```javascript
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
     ```
 
 6.  6

--- a/skills/omnibus/instrument-integration/references/android.md
+++ b/skills/omnibus/instrument-integration/references/android.md
@@ -444,7 +444,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -459,7 +459,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 

--- a/skills/omnibus/instrument-integration/references/flutter.md
+++ b/skills/omnibus/instrument-integration/references/flutter.md
@@ -534,7 +534,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -548,7 +548,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/omnibus/instrument-integration/references/posthog-js.md
+++ b/skills/omnibus/instrument-integration/references/posthog-js.md
@@ -1805,8 +1805,9 @@ Get feature flag payload value matching key for user (supports multivariate flag
 ### Examples
 
 ```ts
-if(posthog.getFeatureFlag('beta-feature') === 'some-value') {
-     const someValue = posthog.getFeatureFlagResult('beta-feature')?.payload
+const betaFeature = posthog.getFeatureFlagResult('beta-feature')
+if (betaFeature?.variant === 'some-value') {
+     const someValue = betaFeature?.payload
      // do something
 }
 ```

--- a/skills/omnibus/instrument-integration/references/posthog-js.md
+++ b/skills/omnibus/instrument-integration/references/posthog-js.md
@@ -1806,7 +1806,7 @@ Get feature flag payload value matching key for user (supports multivariate flag
 
 ```ts
 if(posthog.getFeatureFlag('beta-feature') === 'some-value') {
-     const someValue = posthog.getFeatureFlagPayload('beta-feature')
+     const someValue = posthog.getFeatureFlagResult('beta-feature')?.payload
      // do something
 }
 ```

--- a/skills/omnibus/instrument-integration/references/react-native.md
+++ b/skills/omnibus/instrument-integration/references/react-native.md
@@ -752,7 +752,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage

--- a/skills/omnibus/instrument-integration/references/usage.md
+++ b/skills/omnibus/instrument-integration/references/usage.md
@@ -482,7 +482,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -496,7 +496,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 

--- a/skills/omnibus/instrument-product-analytics/references/android.md
+++ b/skills/omnibus/instrument-product-analytics/references/android.md
@@ -444,7 +444,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -459,7 +459,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 

--- a/skills/omnibus/instrument-product-analytics/references/flutter.md
+++ b/skills/omnibus/instrument-product-analytics/references/flutter.md
@@ -534,7 +534,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -548,7 +548,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/omnibus/instrument-product-analytics/references/react-native.md
+++ b/skills/omnibus/instrument-product-analytics/references/react-native.md
@@ -752,7 +752,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage

--- a/skills/omnibus/instrument-product-analytics/references/usage.md
+++ b/skills/omnibus/instrument-product-analytics/references/usage.md
@@ -482,7 +482,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -496,7 +496,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 

--- a/skills/posthog/all/skills/feature-flags-android/references/adding-feature-flag-code.md
+++ b/skills/posthog/all/skills/feature-flags-android/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1777,7 +1777,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1988,7 +1988,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2003,7 +2003,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2064,7 +2064,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2078,7 +2078,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2157,7 +2157,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2171,7 +2171,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/posthog/all/skills/feature-flags-android/references/android.md
+++ b/skills/posthog/all/skills/feature-flags-android/references/android.md
@@ -88,7 +88,7 @@
     if (isMyFlagEnabled) {
         // Do something differently for this user
         // Optional: fetch the payload
-        val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+        val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
     }
     ```
 
@@ -109,7 +109,7 @@
     if (enabledVariant == "variant-key") { // replace 'variant-key' with the key of your variant
         // Do something differently for this user
         // Optional: fetch the payload
-        val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+        val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
     }
     ```
 

--- a/skills/posthog/all/skills/feature-flags-api/references/adding-feature-flag-code.md
+++ b/skills/posthog/all/skills/feature-flags-api/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1777,7 +1777,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1988,7 +1988,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2003,7 +2003,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2064,7 +2064,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2078,7 +2078,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2157,7 +2157,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2171,7 +2171,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/posthog/all/skills/feature-flags-dotnet/references/adding-feature-flag-code.md
+++ b/skills/posthog/all/skills/feature-flags-dotnet/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1777,7 +1777,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1988,7 +1988,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2003,7 +2003,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2064,7 +2064,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2078,7 +2078,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2157,7 +2157,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2171,7 +2171,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/posthog/all/skills/feature-flags-elixir/references/adding-feature-flag-code.md
+++ b/skills/posthog/all/skills/feature-flags-elixir/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1777,7 +1777,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1988,7 +1988,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2003,7 +2003,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2064,7 +2064,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2078,7 +2078,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2157,7 +2157,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2171,7 +2171,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/posthog/all/skills/feature-flags-flutter/references/adding-feature-flag-code.md
+++ b/skills/posthog/all/skills/feature-flags-flutter/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1777,7 +1777,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1988,7 +1988,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2003,7 +2003,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2064,7 +2064,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2078,7 +2078,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2157,7 +2157,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2171,7 +2171,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/posthog/all/skills/feature-flags-flutter/references/flutter.md
+++ b/skills/posthog/all/skills/feature-flags-flutter/references/flutter.md
@@ -154,7 +154,7 @@
     if (isMyFlagEnabled) {
         // Do something differently for this user
         // Optional: fetch the payload
-        final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+        final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
     }
     ```
 
@@ -175,7 +175,7 @@
     if (enabledVariant == 'variant-key') { // replace 'variant-key' with the key of your variant
         // Do something differently for this user
         // Optional: fetch the payload
-        final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+        final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
     }
     ```
 

--- a/skills/posthog/all/skills/feature-flags-go/references/adding-feature-flag-code.md
+++ b/skills/posthog/all/skills/feature-flags-go/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1777,7 +1777,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1988,7 +1988,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2003,7 +2003,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2064,7 +2064,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2078,7 +2078,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2157,7 +2157,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2171,7 +2171,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/posthog/all/skills/feature-flags-ios/references/adding-feature-flag-code.md
+++ b/skills/posthog/all/skills/feature-flags-ios/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1777,7 +1777,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1988,7 +1988,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2003,7 +2003,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2064,7 +2064,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2078,7 +2078,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2157,7 +2157,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2171,7 +2171,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/posthog/all/skills/feature-flags-ios/references/ios.md
+++ b/skills/posthog/all/skills/feature-flags-ios/references/ios.md
@@ -88,7 +88,7 @@
     if isMyFlagEnabled {
         // Do something differently for this user
         // Optional: fetch the payload
-        let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+        let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
     }
     ```
 
@@ -109,7 +109,7 @@
     if enabledVariant == "variant-key" { // replace 'variant-key' with the key of your variant
         // Do something differently for this user
         // Optional: fetch the payload
-        let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+        let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
     }
     ```
 

--- a/skills/posthog/all/skills/feature-flags-java/references/adding-feature-flag-code.md
+++ b/skills/posthog/all/skills/feature-flags-java/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1777,7 +1777,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1988,7 +1988,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2003,7 +2003,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2064,7 +2064,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2078,7 +2078,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2157,7 +2157,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2171,7 +2171,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/posthog/all/skills/feature-flags-nextjs/references/adding-feature-flag-code.md
+++ b/skills/posthog/all/skills/feature-flags-nextjs/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1777,7 +1777,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1988,7 +1988,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2003,7 +2003,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2064,7 +2064,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2078,7 +2078,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2157,7 +2157,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2171,7 +2171,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/posthog/all/skills/feature-flags-nodejs/references/adding-feature-flag-code.md
+++ b/skills/posthog/all/skills/feature-flags-nodejs/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1777,7 +1777,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1988,7 +1988,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2003,7 +2003,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2064,7 +2064,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2078,7 +2078,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2157,7 +2157,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2171,7 +2171,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/posthog/all/skills/feature-flags-php/references/adding-feature-flag-code.md
+++ b/skills/posthog/all/skills/feature-flags-php/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1777,7 +1777,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1988,7 +1988,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2003,7 +2003,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2064,7 +2064,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2078,7 +2078,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2157,7 +2157,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2171,7 +2171,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/posthog/all/skills/feature-flags-python/references/adding-feature-flag-code.md
+++ b/skills/posthog/all/skills/feature-flags-python/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1777,7 +1777,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1988,7 +1988,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2003,7 +2003,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2064,7 +2064,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2078,7 +2078,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2157,7 +2157,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2171,7 +2171,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/posthog/all/skills/feature-flags-react-native/references/adding-feature-flag-code.md
+++ b/skills/posthog/all/skills/feature-flags-react-native/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1777,7 +1777,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1988,7 +1988,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2003,7 +2003,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2064,7 +2064,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2078,7 +2078,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2157,7 +2157,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2171,7 +2171,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/posthog/all/skills/feature-flags-react-native/references/react-native.md
+++ b/skills/posthog/all/skills/feature-flags-react-native/references/react-native.md
@@ -105,7 +105,7 @@
         if (isMyFlagEnabled) {
             // Do something differently for this user
             // Optional: fetch the payload
-            const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+            const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
         }
         return <View>...</View>
     }
@@ -127,7 +127,7 @@
         if (enabledVariant === 'variant-key') { // replace 'variant-key' with the key of your variant
             // Do something differently for this user
             // Optional: fetch the payload
-            const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+            const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
         }
         return <View>...</View>
     }

--- a/skills/posthog/all/skills/feature-flags-react/references/adding-feature-flag-code.md
+++ b/skills/posthog/all/skills/feature-flags-react/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1777,7 +1777,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1988,7 +1988,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2003,7 +2003,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2064,7 +2064,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2078,7 +2078,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2157,7 +2157,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2171,7 +2171,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/posthog/all/skills/feature-flags-ruby/references/adding-feature-flag-code.md
+++ b/skills/posthog/all/skills/feature-flags-ruby/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1777,7 +1777,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1988,7 +1988,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2003,7 +2003,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2064,7 +2064,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2078,7 +2078,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2157,7 +2157,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2171,7 +2171,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/posthog/all/skills/feature-flags-rust/references/adding-feature-flag-code.md
+++ b/skills/posthog/all/skills/feature-flags-rust/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1777,7 +1777,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1988,7 +1988,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2003,7 +2003,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2064,7 +2064,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2078,7 +2078,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2157,7 +2157,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2171,7 +2171,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/posthog/all/skills/feature-flags-web/references/adding-feature-flag-code.md
+++ b/skills/posthog/all/skills/feature-flags-web/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1777,7 +1777,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1988,7 +1988,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2003,7 +2003,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2064,7 +2064,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2078,7 +2078,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2157,7 +2157,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2171,7 +2171,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/posthog/all/skills/feature-flags-web/references/web.md
+++ b/skills/posthog/all/skills/feature-flags-web/references/web.md
@@ -94,7 +94,7 @@
     if (posthog.isFeatureEnabled('flag-key')) {
         // Do something differently for this user
         // Optional: fetch the payload
-        const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+        const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
     }
     ```
 
@@ -110,7 +110,7 @@
     if (posthog.getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
         // Do something differently for this user
         // Optional: fetch the payload
-        const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+        const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
     }
     ```
 
@@ -123,7 +123,7 @@
     Feature flags can include payloads with additional data. Fetch the payload like this:
 
     ```javascript
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
     ```
 
 6.  6

--- a/skills/posthog/all/skills/integration-android/references/android.md
+++ b/skills/posthog/all/skills/integration-android/references/android.md
@@ -442,7 +442,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -457,7 +457,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 

--- a/skills/posthog/all/skills/integration-expo/references/react-native.md
+++ b/skills/posthog/all/skills/integration-expo/references/react-native.md
@@ -737,7 +737,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage

--- a/skills/posthog/all/skills/integration-javascript_web/references/posthog-js.md
+++ b/skills/posthog/all/skills/integration-javascript_web/references/posthog-js.md
@@ -1707,7 +1707,7 @@ Get feature flag payload value matching key for user (supports multivariate flag
 
 ```ts
 if(posthog.getFeatureFlag('beta-feature') === 'some-value') {
-     const someValue = posthog.getFeatureFlagPayload('beta-feature')
+     const someValue = posthog.getFeatureFlagResult('beta-feature')?.payload
      // do something
 }
 ```

--- a/skills/posthog/all/skills/integration-javascript_web/references/posthog-js.md
+++ b/skills/posthog/all/skills/integration-javascript_web/references/posthog-js.md
@@ -1706,8 +1706,9 @@ Get feature flag payload value matching key for user (supports multivariate flag
 ### Examples
 
 ```ts
-if(posthog.getFeatureFlag('beta-feature') === 'some-value') {
-     const someValue = posthog.getFeatureFlagResult('beta-feature')?.payload
+const betaFeature = posthog.getFeatureFlagResult('beta-feature')
+if (betaFeature?.variant === 'some-value') {
+     const someValue = betaFeature?.payload
      // do something
 }
 ```

--- a/skills/posthog/all/skills/integration-react-native/references/react-native.md
+++ b/skills/posthog/all/skills/integration-react-native/references/react-native.md
@@ -737,7 +737,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage

--- a/skills/posthog/all/skills/omnibus-instrument-feature-flags/references/adding-feature-flag-code.md
+++ b/skills/posthog/all/skills/omnibus-instrument-feature-flags/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1777,7 +1777,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1988,7 +1988,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2003,7 +2003,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2064,7 +2064,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2078,7 +2078,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2157,7 +2157,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2171,7 +2171,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/posthog/all/skills/omnibus-instrument-feature-flags/references/android.md
+++ b/skills/posthog/all/skills/omnibus-instrument-feature-flags/references/android.md
@@ -88,7 +88,7 @@
     if (isMyFlagEnabled) {
         // Do something differently for this user
         // Optional: fetch the payload
-        val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+        val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
     }
     ```
 
@@ -109,7 +109,7 @@
     if (enabledVariant == "variant-key") { // replace 'variant-key' with the key of your variant
         // Do something differently for this user
         // Optional: fetch the payload
-        val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+        val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
     }
     ```
 

--- a/skills/posthog/all/skills/omnibus-instrument-feature-flags/references/flutter.md
+++ b/skills/posthog/all/skills/omnibus-instrument-feature-flags/references/flutter.md
@@ -154,7 +154,7 @@
     if (isMyFlagEnabled) {
         // Do something differently for this user
         // Optional: fetch the payload
-        final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+        final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
     }
     ```
 
@@ -175,7 +175,7 @@
     if (enabledVariant == 'variant-key') { // replace 'variant-key' with the key of your variant
         // Do something differently for this user
         // Optional: fetch the payload
-        final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+        final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
     }
     ```
 

--- a/skills/posthog/all/skills/omnibus-instrument-feature-flags/references/ios.md
+++ b/skills/posthog/all/skills/omnibus-instrument-feature-flags/references/ios.md
@@ -88,7 +88,7 @@
     if isMyFlagEnabled {
         // Do something differently for this user
         // Optional: fetch the payload
-        let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+        let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
     }
     ```
 
@@ -109,7 +109,7 @@
     if enabledVariant == "variant-key" { // replace 'variant-key' with the key of your variant
         // Do something differently for this user
         // Optional: fetch the payload
-        let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+        let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
     }
     ```
 

--- a/skills/posthog/all/skills/omnibus-instrument-feature-flags/references/react-native.md
+++ b/skills/posthog/all/skills/omnibus-instrument-feature-flags/references/react-native.md
@@ -105,7 +105,7 @@
         if (isMyFlagEnabled) {
             // Do something differently for this user
             // Optional: fetch the payload
-            const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+            const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
         }
         return <View>...</View>
     }
@@ -127,7 +127,7 @@
         if (enabledVariant === 'variant-key') { // replace 'variant-key' with the key of your variant
             // Do something differently for this user
             // Optional: fetch the payload
-            const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+            const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
         }
         return <View>...</View>
     }

--- a/skills/posthog/all/skills/omnibus-instrument-feature-flags/references/web.md
+++ b/skills/posthog/all/skills/omnibus-instrument-feature-flags/references/web.md
@@ -94,7 +94,7 @@
     if (posthog.isFeatureEnabled('flag-key')) {
         // Do something differently for this user
         // Optional: fetch the payload
-        const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+        const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
     }
     ```
 
@@ -110,7 +110,7 @@
     if (posthog.getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
         // Do something differently for this user
         // Optional: fetch the payload
-        const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+        const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
     }
     ```
 
@@ -123,7 +123,7 @@
     Feature flags can include payloads with additional data. Fetch the payload like this:
 
     ```javascript
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
     ```
 
 6.  6

--- a/skills/posthog/all/skills/omnibus-instrument-integration/references/android.md
+++ b/skills/posthog/all/skills/omnibus-instrument-integration/references/android.md
@@ -442,7 +442,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -457,7 +457,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 

--- a/skills/posthog/all/skills/omnibus-instrument-integration/references/posthog-js.md
+++ b/skills/posthog/all/skills/omnibus-instrument-integration/references/posthog-js.md
@@ -1707,7 +1707,7 @@ Get feature flag payload value matching key for user (supports multivariate flag
 
 ```ts
 if(posthog.getFeatureFlag('beta-feature') === 'some-value') {
-     const someValue = posthog.getFeatureFlagPayload('beta-feature')
+     const someValue = posthog.getFeatureFlagResult('beta-feature')?.payload
      // do something
 }
 ```

--- a/skills/posthog/all/skills/omnibus-instrument-integration/references/posthog-js.md
+++ b/skills/posthog/all/skills/omnibus-instrument-integration/references/posthog-js.md
@@ -1706,8 +1706,9 @@ Get feature flag payload value matching key for user (supports multivariate flag
 ### Examples
 
 ```ts
-if(posthog.getFeatureFlag('beta-feature') === 'some-value') {
-     const someValue = posthog.getFeatureFlagResult('beta-feature')?.payload
+const betaFeature = posthog.getFeatureFlagResult('beta-feature')
+if (betaFeature?.variant === 'some-value') {
+     const someValue = betaFeature?.payload
      // do something
 }
 ```

--- a/skills/posthog/all/skills/omnibus-instrument-integration/references/react-native.md
+++ b/skills/posthog/all/skills/omnibus-instrument-integration/references/react-native.md
@@ -737,7 +737,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage

--- a/skills/posthog/all/skills/omnibus-instrument-product-analytics/references/android.md
+++ b/skills/posthog/all/skills/omnibus-instrument-product-analytics/references/android.md
@@ -442,7 +442,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -457,7 +457,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 

--- a/skills/posthog/all/skills/omnibus-instrument-product-analytics/references/react-native.md
+++ b/skills/posthog/all/skills/omnibus-instrument-product-analytics/references/react-native.md
@@ -737,7 +737,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage

--- a/skills/posthog/feature-flags/skills/all/references/adding-feature-flag-code.md
+++ b/skills/posthog/feature-flags/skills/all/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1777,7 +1777,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1988,7 +1988,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2003,7 +2003,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2064,7 +2064,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2078,7 +2078,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2157,7 +2157,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2171,7 +2171,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/posthog/feature-flags/skills/all/references/android.md
+++ b/skills/posthog/feature-flags/skills/all/references/android.md
@@ -88,7 +88,7 @@
     if (isMyFlagEnabled) {
         // Do something differently for this user
         // Optional: fetch the payload
-        val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+        val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
     }
     ```
 
@@ -109,7 +109,7 @@
     if (enabledVariant == "variant-key") { // replace 'variant-key' with the key of your variant
         // Do something differently for this user
         // Optional: fetch the payload
-        val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+        val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
     }
     ```
 

--- a/skills/posthog/feature-flags/skills/all/references/flutter.md
+++ b/skills/posthog/feature-flags/skills/all/references/flutter.md
@@ -154,7 +154,7 @@
     if (isMyFlagEnabled) {
         // Do something differently for this user
         // Optional: fetch the payload
-        final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+        final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
     }
     ```
 
@@ -175,7 +175,7 @@
     if (enabledVariant == 'variant-key') { // replace 'variant-key' with the key of your variant
         // Do something differently for this user
         // Optional: fetch the payload
-        final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+        final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
     }
     ```
 

--- a/skills/posthog/feature-flags/skills/all/references/ios.md
+++ b/skills/posthog/feature-flags/skills/all/references/ios.md
@@ -88,7 +88,7 @@
     if isMyFlagEnabled {
         // Do something differently for this user
         // Optional: fetch the payload
-        let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+        let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
     }
     ```
 
@@ -109,7 +109,7 @@
     if enabledVariant == "variant-key" { // replace 'variant-key' with the key of your variant
         // Do something differently for this user
         // Optional: fetch the payload
-        let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+        let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
     }
     ```
 

--- a/skills/posthog/feature-flags/skills/all/references/react-native.md
+++ b/skills/posthog/feature-flags/skills/all/references/react-native.md
@@ -105,7 +105,7 @@
         if (isMyFlagEnabled) {
             // Do something differently for this user
             // Optional: fetch the payload
-            const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+            const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
         }
         return <View>...</View>
     }
@@ -127,7 +127,7 @@
         if (enabledVariant === 'variant-key') { // replace 'variant-key' with the key of your variant
             // Do something differently for this user
             // Optional: fetch the payload
-            const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+            const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
         }
         return <View>...</View>
     }

--- a/skills/posthog/feature-flags/skills/all/references/web.md
+++ b/skills/posthog/feature-flags/skills/all/references/web.md
@@ -94,7 +94,7 @@
     if (posthog.isFeatureEnabled('flag-key')) {
         // Do something differently for this user
         // Optional: fetch the payload
-        const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+        const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
     }
     ```
 
@@ -110,7 +110,7 @@
     if (posthog.getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
         // Do something differently for this user
         // Optional: fetch the payload
-        const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+        const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
     }
     ```
 
@@ -123,7 +123,7 @@
     Feature flags can include payloads with additional data. Fetch the payload like this:
 
     ```javascript
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
     ```
 
 6.  6

--- a/skills/posthog/feature-flags/skills/android/references/adding-feature-flag-code.md
+++ b/skills/posthog/feature-flags/skills/android/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1777,7 +1777,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1988,7 +1988,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2003,7 +2003,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2064,7 +2064,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2078,7 +2078,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2157,7 +2157,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2171,7 +2171,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/posthog/feature-flags/skills/android/references/android.md
+++ b/skills/posthog/feature-flags/skills/android/references/android.md
@@ -88,7 +88,7 @@
     if (isMyFlagEnabled) {
         // Do something differently for this user
         // Optional: fetch the payload
-        val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+        val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
     }
     ```
 
@@ -109,7 +109,7 @@
     if (enabledVariant == "variant-key") { // replace 'variant-key' with the key of your variant
         // Do something differently for this user
         // Optional: fetch the payload
-        val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+        val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
     }
     ```
 

--- a/skills/posthog/feature-flags/skills/api/references/adding-feature-flag-code.md
+++ b/skills/posthog/feature-flags/skills/api/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1777,7 +1777,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1988,7 +1988,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2003,7 +2003,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2064,7 +2064,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2078,7 +2078,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2157,7 +2157,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2171,7 +2171,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/posthog/feature-flags/skills/dotnet/references/adding-feature-flag-code.md
+++ b/skills/posthog/feature-flags/skills/dotnet/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1777,7 +1777,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1988,7 +1988,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2003,7 +2003,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2064,7 +2064,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2078,7 +2078,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2157,7 +2157,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2171,7 +2171,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/posthog/feature-flags/skills/elixir/references/adding-feature-flag-code.md
+++ b/skills/posthog/feature-flags/skills/elixir/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1777,7 +1777,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1988,7 +1988,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2003,7 +2003,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2064,7 +2064,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2078,7 +2078,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2157,7 +2157,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2171,7 +2171,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/posthog/feature-flags/skills/flutter/references/adding-feature-flag-code.md
+++ b/skills/posthog/feature-flags/skills/flutter/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1777,7 +1777,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1988,7 +1988,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2003,7 +2003,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2064,7 +2064,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2078,7 +2078,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2157,7 +2157,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2171,7 +2171,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/posthog/feature-flags/skills/flutter/references/flutter.md
+++ b/skills/posthog/feature-flags/skills/flutter/references/flutter.md
@@ -154,7 +154,7 @@
     if (isMyFlagEnabled) {
         // Do something differently for this user
         // Optional: fetch the payload
-        final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+        final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
     }
     ```
 
@@ -175,7 +175,7 @@
     if (enabledVariant == 'variant-key') { // replace 'variant-key' with the key of your variant
         // Do something differently for this user
         // Optional: fetch the payload
-        final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+        final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
     }
     ```
 

--- a/skills/posthog/feature-flags/skills/go/references/adding-feature-flag-code.md
+++ b/skills/posthog/feature-flags/skills/go/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1777,7 +1777,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1988,7 +1988,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2003,7 +2003,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2064,7 +2064,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2078,7 +2078,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2157,7 +2157,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2171,7 +2171,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/posthog/feature-flags/skills/ios/references/adding-feature-flag-code.md
+++ b/skills/posthog/feature-flags/skills/ios/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1777,7 +1777,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1988,7 +1988,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2003,7 +2003,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2064,7 +2064,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2078,7 +2078,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2157,7 +2157,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2171,7 +2171,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/posthog/feature-flags/skills/ios/references/ios.md
+++ b/skills/posthog/feature-flags/skills/ios/references/ios.md
@@ -88,7 +88,7 @@
     if isMyFlagEnabled {
         // Do something differently for this user
         // Optional: fetch the payload
-        let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+        let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
     }
     ```
 
@@ -109,7 +109,7 @@
     if enabledVariant == "variant-key" { // replace 'variant-key' with the key of your variant
         // Do something differently for this user
         // Optional: fetch the payload
-        let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+        let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
     }
     ```
 

--- a/skills/posthog/feature-flags/skills/java/references/adding-feature-flag-code.md
+++ b/skills/posthog/feature-flags/skills/java/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1777,7 +1777,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1988,7 +1988,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2003,7 +2003,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2064,7 +2064,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2078,7 +2078,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2157,7 +2157,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2171,7 +2171,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/posthog/feature-flags/skills/nextjs/references/adding-feature-flag-code.md
+++ b/skills/posthog/feature-flags/skills/nextjs/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1777,7 +1777,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1988,7 +1988,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2003,7 +2003,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2064,7 +2064,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2078,7 +2078,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2157,7 +2157,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2171,7 +2171,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/posthog/feature-flags/skills/nodejs/references/adding-feature-flag-code.md
+++ b/skills/posthog/feature-flags/skills/nodejs/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1777,7 +1777,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1988,7 +1988,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2003,7 +2003,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2064,7 +2064,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2078,7 +2078,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2157,7 +2157,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2171,7 +2171,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/posthog/feature-flags/skills/php/references/adding-feature-flag-code.md
+++ b/skills/posthog/feature-flags/skills/php/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1777,7 +1777,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1988,7 +1988,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2003,7 +2003,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2064,7 +2064,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2078,7 +2078,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2157,7 +2157,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2171,7 +2171,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/posthog/feature-flags/skills/python/references/adding-feature-flag-code.md
+++ b/skills/posthog/feature-flags/skills/python/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1777,7 +1777,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1988,7 +1988,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2003,7 +2003,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2064,7 +2064,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2078,7 +2078,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2157,7 +2157,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2171,7 +2171,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/posthog/feature-flags/skills/react-native/references/adding-feature-flag-code.md
+++ b/skills/posthog/feature-flags/skills/react-native/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1777,7 +1777,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1988,7 +1988,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2003,7 +2003,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2064,7 +2064,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2078,7 +2078,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2157,7 +2157,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2171,7 +2171,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/posthog/feature-flags/skills/react-native/references/react-native.md
+++ b/skills/posthog/feature-flags/skills/react-native/references/react-native.md
@@ -105,7 +105,7 @@
         if (isMyFlagEnabled) {
             // Do something differently for this user
             // Optional: fetch the payload
-            const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+            const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
         }
         return <View>...</View>
     }
@@ -127,7 +127,7 @@
         if (enabledVariant === 'variant-key') { // replace 'variant-key' with the key of your variant
             // Do something differently for this user
             // Optional: fetch the payload
-            const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+            const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
         }
         return <View>...</View>
     }

--- a/skills/posthog/feature-flags/skills/react/references/adding-feature-flag-code.md
+++ b/skills/posthog/feature-flags/skills/react/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1777,7 +1777,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1988,7 +1988,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2003,7 +2003,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2064,7 +2064,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2078,7 +2078,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2157,7 +2157,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2171,7 +2171,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/posthog/feature-flags/skills/ruby/references/adding-feature-flag-code.md
+++ b/skills/posthog/feature-flags/skills/ruby/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1777,7 +1777,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1988,7 +1988,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2003,7 +2003,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2064,7 +2064,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2078,7 +2078,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2157,7 +2157,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2171,7 +2171,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/posthog/feature-flags/skills/rust/references/adding-feature-flag-code.md
+++ b/skills/posthog/feature-flags/skills/rust/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1777,7 +1777,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1988,7 +1988,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2003,7 +2003,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2064,7 +2064,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2078,7 +2078,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2157,7 +2157,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2171,7 +2171,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/posthog/feature-flags/skills/web/references/adding-feature-flag-code.md
+++ b/skills/posthog/feature-flags/skills/web/references/adding-feature-flag-code.md
@@ -14,7 +14,7 @@ PostHog AI
 if (posthog.isFeatureEnabled('flag-key') ) {
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -28,7 +28,7 @@ PostHog AI
 if (posthog.getFeatureFlag('flag-key')  == 'variant-key') { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
 }
 ```
 
@@ -1777,7 +1777,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage
@@ -1988,7 +1988,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2003,7 +2003,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2064,7 +2064,7 @@ PostHog AI
 if (PostHogSDK.shared.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2078,7 +2078,7 @@ PostHog AI
 if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagPayload("flag-key")
+    let matchedFlagPayload = PostHogSDK.shared.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -2157,7 +2157,7 @@ PostHog AI
 if (await Posthog().isFeatureEnabled('flag-key')) {
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 
@@ -2171,7 +2171,7 @@ PostHog AI
 if (await Posthog().getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
   // Do something differently for this user
   // Optional: fetch the payload
-  final matchedFlagPayload = await Posthog().getFeatureFlagPayload('flag-key');
+  final matchedFlagPayload = (await Posthog().getFeatureFlagResult('flag-key'))?.payload;
 }
 ```
 

--- a/skills/posthog/feature-flags/skills/web/references/web.md
+++ b/skills/posthog/feature-flags/skills/web/references/web.md
@@ -94,7 +94,7 @@
     if (posthog.isFeatureEnabled('flag-key')) {
         // Do something differently for this user
         // Optional: fetch the payload
-        const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+        const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
     }
     ```
 
@@ -110,7 +110,7 @@
     if (posthog.getFeatureFlag('flag-key') == 'variant-key') { // replace 'variant-key' with the key of your variant
         // Do something differently for this user
         // Optional: fetch the payload
-        const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+        const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
     }
     ```
 
@@ -123,7 +123,7 @@
     Feature flags can include payloads with additional data. Fetch the payload like this:
 
     ```javascript
-    const matchedFlagPayload = posthog.getFeatureFlagPayload('flag-key')
+    const matchedFlagPayload = posthog.getFeatureFlagResult('flag-key')?.payload
     ```
 
 6.  6

--- a/skills/posthog/integration/skills/all/references/android.md
+++ b/skills/posthog/integration/skills/all/references/android.md
@@ -442,7 +442,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -457,7 +457,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 

--- a/skills/posthog/integration/skills/all/references/posthog-js.md
+++ b/skills/posthog/integration/skills/all/references/posthog-js.md
@@ -1707,7 +1707,7 @@ Get feature flag payload value matching key for user (supports multivariate flag
 
 ```ts
 if(posthog.getFeatureFlag('beta-feature') === 'some-value') {
-     const someValue = posthog.getFeatureFlagPayload('beta-feature')
+     const someValue = posthog.getFeatureFlagResult('beta-feature')?.payload
      // do something
 }
 ```

--- a/skills/posthog/integration/skills/all/references/posthog-js.md
+++ b/skills/posthog/integration/skills/all/references/posthog-js.md
@@ -1706,8 +1706,9 @@ Get feature flag payload value matching key for user (supports multivariate flag
 ### Examples
 
 ```ts
-if(posthog.getFeatureFlag('beta-feature') === 'some-value') {
-     const someValue = posthog.getFeatureFlagResult('beta-feature')?.payload
+const betaFeature = posthog.getFeatureFlagResult('beta-feature')
+if (betaFeature?.variant === 'some-value') {
+     const someValue = betaFeature?.payload
      // do something
 }
 ```

--- a/skills/posthog/integration/skills/all/references/react-native.md
+++ b/skills/posthog/integration/skills/all/references/react-native.md
@@ -737,7 +737,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage

--- a/skills/posthog/integration/skills/android/references/android.md
+++ b/skills/posthog/integration/skills/android/references/android.md
@@ -442,7 +442,7 @@ import com.posthog.PostHog
 if (PostHog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 
@@ -457,7 +457,7 @@ import com.posthog.PostHog
 if (PostHog.getFeatureFlag("flag-key") == "variant-key") { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
     // Optional: fetch the payload
-    val matchedFlagPayload = PostHog.getFeatureFlagPayload("flag-key")
+    val matchedFlagPayload = PostHog.getFeatureFlagResult("flag-key")?.payload
 }
 ```
 

--- a/skills/posthog/integration/skills/expo/references/react-native.md
+++ b/skills/posthog/integration/skills/expo/references/react-native.md
@@ -737,7 +737,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage

--- a/skills/posthog/integration/skills/javascript_web/references/posthog-js.md
+++ b/skills/posthog/integration/skills/javascript_web/references/posthog-js.md
@@ -1707,7 +1707,7 @@ Get feature flag payload value matching key for user (supports multivariate flag
 
 ```ts
 if(posthog.getFeatureFlag('beta-feature') === 'some-value') {
-     const someValue = posthog.getFeatureFlagPayload('beta-feature')
+     const someValue = posthog.getFeatureFlagResult('beta-feature')?.payload
      // do something
 }
 ```

--- a/skills/posthog/integration/skills/javascript_web/references/posthog-js.md
+++ b/skills/posthog/integration/skills/javascript_web/references/posthog-js.md
@@ -1706,8 +1706,9 @@ Get feature flag payload value matching key for user (supports multivariate flag
 ### Examples
 
 ```ts
-if(posthog.getFeatureFlag('beta-feature') === 'some-value') {
-     const someValue = posthog.getFeatureFlagResult('beta-feature')?.payload
+const betaFeature = posthog.getFeatureFlagResult('beta-feature')
+if (betaFeature?.variant === 'some-value') {
+     const someValue = betaFeature?.payload
      // do something
 }
 ```

--- a/skills/posthog/integration/skills/react-native/references/react-native.md
+++ b/skills/posthog/integration/skills/react-native/references/react-native.md
@@ -737,7 +737,7 @@ posthog.getFeatureFlag('key-for-your-boolean-flag')
 // Multivariant feature flags are returned as a string
 posthog.getFeatureFlag('key-for-your-multivariate-flag')
 // Optional fetch the payload returns 'JsonType' or undefined if not loaded yet or if there was a problem loading
-posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
+posthog.getFeatureFlagResult('key-for-your-multivariate-flag')?.payload
 ```
 
 ### Ensuring flags are loaded before usage


### PR DESCRIPTION
## Summary

Migrates the **client-side** `getFeatureFlagPayload(...)` examples in the feature-flag skill references to `getFeatureFlagResult(...)?.payload`, matching the deprecation now in effect across the client SDKs (browser, React Native, iOS, Android, Flutter). `getFeatureFlagResult` returns the flag value and payload from a single evaluation; the imperative `getFeatureFlagPayload` is deprecated in those SDKs.

Only client forms were changed:
- `posthog.getFeatureFlagPayload('…')` → `posthog.getFeatureFlagResult('…')?.payload`
- `await Posthog().getFeatureFlagPayload('…')` → `(await Posthog().getFeatureFlagResult('…'))?.payload`
- `PostHogSDK.shared.getFeatureFlagPayload("…")` → `PostHogSDK.shared.getFeatureFlagResult("…")?.payload`
- `PostHog.getFeatureFlagPayload("…")` → `PostHog.getFeatureFlagResult("…")?.payload`

**Left unchanged** (intentional): backend SDK forms that take a `distinctId` (Node `client.getFeatureFlagPayload(key, distinctId, …)`, Java, PHP `$posthog->`, etc.) — those follow the separate `evaluateFlags()` deprecation — plus the `array.js` loader stubs and prose/heading mentions.

> Note: these reference files appear to be **generated** (the same snippets are duplicated across many per-SDK skill directories). The upstream source on posthog.com has already been migrated, so the generator should reproduce this; this PR fixes the currently committed snapshots so AI agents reading them today get the non-deprecated API.
