### PR TITLE
fix(ci): sign the commits this workflow creates

### DIFF
--- a/.github/workflows/generate-marketplace.yml
+++ b/.github/workflows/generate-marketplace.yml
@@ -21,22 +21,43 @@ jobs:
       - name: Discover plugins and generate marketplace.json
         run: ./scripts/generate-marketplace.sh
 
-      - name: Create PR if marketplace.json changed
+      - name: Check whether marketplace.json changed
+        id: changes
+        run: |
+          if git diff --quiet .claude-plugin/marketplace.json; then
+            echo "No changes to marketplace.json"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Reset the branch to this run's base before committing. ghcommit-action adds
+      # a commit onto an existing remote branch rather than replacing it, so the
+      # force-push here takes the place of the old `git push -f`. It moves the
+      # branch to an already-signed commit, so nothing unsigned reaches the remote.
+      - name: Reset the marketplace branch
+        if: steps.changes.outputs.changed == 'true'
+        run: git push -f origin "HEAD:refs/heads/auto/update-marketplace"
+
+      # Commits through the GitHub API so it carries GitHub's signature, which the
+      # org-wide signed-commits ruleset requires. A plain `git push` is rejected.
+      - name: Commit marketplace.json
+        if: steps.changes.outputs.changed == 'true'
+        uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465 # v0.2.22
+        with:
+          commit_message: Update marketplace.json (auto-discovered plugins)
+          repo: ${{ github.repository }}
+          branch: auto/update-marketplace
+          file_pattern: .claude-plugin/marketplace.json
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Open PR if marketplace.json changed
+        if: steps.changes.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .claude-plugin/marketplace.json
-          if git diff --cached --quiet; then
-            echo "No changes to marketplace.json"
-            exit 0
-          fi
-
           BRANCH="auto/update-marketplace"
-          git checkout -B "$BRANCH"
-          git commit -m "Update marketplace.json (auto-discovered plugins)"
-          git push -f origin "$BRANCH"
 
           # Create PR if one doesn't already exist
           EXISTING=$(gh pr list --head "$BRANCH" --state open --json number --jq 'length')


### PR DESCRIPTION
## Summary

Makes the workflow that commits in this repo produce **signed** commits.

Commits created with plain `git` are unsigned. PostHog is rolling the org-wide "Require signed commits" ruleset out to every repo, and this workflow would be rejected with `GH013` once it applies here. Routing the commit through the GitHub API instead means GitHub signs it with its own key, so it lands verified.

Found while inventorying which workflows across the org still create unsigned commits. `planetscale/ghcommit-action` is the pattern already in use in `posthog-js`, `posthog-roblox`, `brand`, `charts` and the SDK release fleet.

## Changes

`generate-marketplace` now force-pushes the branch to the run's base commit (already signed) and commits `marketplace.json` onto it through the API, replacing the old `git commit` + `git push -f`.

## Testing

Not run end to end. The force-push preserves the old reuse-one-branch behavior; it only ever moves the branch to a commit that is already on `main`.
