### PR TITLE
Merge 'seansoh/qol-changes'...

### DIFF
--- a/skills/team/customer-success/impersonation-toolkit/.claude-plugin/plugin.json
+++ b/skills/team/customer-success/impersonation-toolkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "impersonation-toolkit",
-  "description": "Run safer impersonation-scoped audits against a customer's PostHog project via Claude Code + the PostHog MCP plugin. Read-only by default; prompts before any mutative MCP call. Includes a shell wrapper for setting up impersonation folders and a permissions template that scopes each session.",
-  "version": "1.0.1",
+  "description": "Run impersonation-scoped audits against a customer's PostHog project via Claude Code + the PostHog MCP plugin. Audits are read-only, enforced server-side by PostHog's read-only impersonation. Includes a shell wrapper that sets up a per-account audit folder and a shared permissions template that pre-approves read tools.",
+  "version": "1.1.0",
   "author": { "name": "PostHog" },
   "keywords": ["posthog", "impersonation", "audit", "customer-success", "experiments"]
 }

--- a/skills/team/customer-success/impersonation-toolkit/README.md
+++ b/skills/team/customer-success/impersonation-toolkit/README.md
@@ -98,13 +98,16 @@ It renames folders to their slug form, drops the `audit-` prefix from audit file
 
 ## Security model
 
-An audit run through this toolkit is read-only, and that is enforced by PostHog, server-side, not by anything in this repo.
+Audits are read-only, enforced server-side by PostHog. The OAuth token minted from a read-only impersonation session has every write scope stripped before issue, and the API rejects mutating requests made with it. The toolkit mints no credentials of its own and can grant itself nothing.
 
-The session uses the OAuth token minted from your read-only impersonation session. PostHog strips every write scope from that token before issuing it, and rejects any mutating request made with it. An audit can read a customer's project; it cannot change one. This toolkit mints no credentials of its own and can grant itself nothing.
+## Permissions file — what it does
 
-## Permissions file
+Purely operational: a PostHog audit calls dozens of read tools, and without an allowlist each one stops for approval. `assets/settings.local.json` pre-approves the read tools so a run goes start to finish, and leaves everything else to prompt normally.
 
-Separate concern, and purely convenience: a PostHog account audit calls dozens of read tools, and without an allowlist each one stops for approval. `assets/settings.local.json` pre-approves the read tools so an audit runs start to finish, and leaves everything else to prompt normally.
+The template also keeps an `ask` list for mutation-shaped tool names (`*-create`, `*-update`, `*-delete`, `execute-sql`). Not a safety layer — the server rejects writes with a read-only token regardless — but two useful side-effects:
+
+- **Awareness.** A prompt during a read-only audit is a signal worth noticing, even though the request would fail.
+- **Documentation of intent.** The list tells a new CSM which tools are treated as sensitive by convention.
 
 It is merged into a single `.claude/settings.local.json` at the root of your impersonation tree. Claude launches at that root, so one file covers every account. Account folders are where output lands, not separate workspaces:
 

--- a/skills/team/customer-success/impersonation-toolkit/README.md
+++ b/skills/team/customer-success/impersonation-toolkit/README.md
@@ -1,10 +1,12 @@
 # impersonation-toolkit
 
-Run safer impersonation-scoped audits against a customer's PostHog project via Claude Code + the PostHog MCP plugin.
+Run impersonation-scoped audits against a customer's PostHog project via Claude Code + the PostHog MCP plugin.
+
+Audits run under PostHog's read-only impersonation, which is enforced server-side — see [Security model](#security-model).
 
 **What it gives you:**
 - One command to spin up an impersonation audit folder per customer
-- A permissions config that auto-approves reads and creates but always prompts on updates, deletes, or archives — so Claude can investigate freely without ever silently mutating a customer's project
+- A permissions config that pre-approves the read tools, so an audit runs start to finish instead of stopping for approval dozens of times. One file for all your accounts, and it keeps whatever you approve mid-session
 - A reusable audit playbook (the `experiment-audit` skill) that walks through experiment config, exposure, attribution, and metrics in a Slack-ready format
 
 ## Prerequisites
@@ -20,61 +22,105 @@ Run safer impersonation-scoped audits against a customer's PostHog project via C
 /plugin install impersonation-toolkit@PostHog-skills
 ```
 
-Then create a tiny shim in `~/bin/` so the wrapper script always picks up the latest installed version of the plugin (run this once — no need to re-run after `claude plugin update`):
+Then drop the launcher shim into `~/bin/` so the wrapper always picks up the latest installed version of the plugin (run this once — no need to re-run after `claude plugin update`):
 
 ```bash
-mkdir -p ~/bin && cat > ~/bin/impersonate-audit <<'EOF'
-#!/usr/bin/env bash
-LATEST=$(ls -1d ~/.claude/plugins/cache/PostHog-skills/impersonation-toolkit/*/ 2>/dev/null | sort -V | tail -1)
-if [[ -z "$LATEST" ]]; then
-  echo "impersonation-toolkit plugin not installed. Run: /plugin install impersonation-toolkit@PostHog-skills" >&2
-  exit 1
-fi
-exec "${LATEST}scripts/impersonate-audit.sh" "$@"
-EOF
+mkdir -p ~/bin
+cp "$(ls -d ~/.claude/plugins/cache/PostHog-skills/impersonation-toolkit/*/ | sort -V | tail -1)scripts/impersonate-audit-shim.sh" ~/bin/impersonate-audit
 chmod +x ~/bin/impersonate-audit
 ```
 
 Confirm `~/bin` is on your PATH (add `export PATH="$HOME/bin:$PATH"` to your `~/.zshrc` or `~/.bashrc` if not).
 
+The shim makes two separate checks before handing off: **is the plugin installed** (hard error, with the install command) and **is the copy stale** (warning only, at most once a day, with the update command). Silence the freshness warning with `CSM_IMPERSONATE_STALE_DAYS=0`, or widen it to a week with `=7`.
+
 ## Usage
 
 ```bash
-impersonate-audit <customer-slug>
+impersonate-audit <account name>
 ```
 
 For example:
 
 ```bash
-impersonate-audit givebutter
+impersonate-audit globex
+impersonate-audit "Acme Inc"      # quotes optional — the words get joined
 ```
 
 The script will:
 
-1. Create (or reuse) `~/impersonate/<customer-slug>/` and refresh the permissions config from the plugin's template
-2. Pause and remind you to impersonate the customer's user in Django Admin (manual step — pick **read-only** by default; only pick read+write if you'll actually need to create something in the customer's account during the audit, e.g. an example experiment or dashboard)
-3. Launch Claude Code in the folder
+1. Create (or reuse) `~/impersonate/<account-slug>/` — lowercase, with runs of spaces and punctuation collapsed to single hyphens, so `Acme Inc` and `Café Söda, Inc.` become `acme-inc` and `cafe-soda-inc`
+2. Pause and remind you to impersonate the customer's user in Django Admin (manual step, and read-only — that's the default and what an audit needs)
+3. Launch Claude Code at the impersonation root, with that folder ready for output
 4. Inside Claude Code: run `/mcp`, find the `posthog` plugin, **clear authentication** then **authenticate** — this binds a fresh token from your active impersonation session
 5. Sanity check by asking Claude `what project am I in?` — should be the customer's project, not yours
 6. Run the audit by asking e.g. `audit <customer>'s experiment named "<experiment name>"` — the `experiment-audit` skill auto-triggers
 7. On exit, the script auto-disables the posthog plugin if it's still connected and reminds you to log out of Django Admin
 
+Audits are written to `<account-slug>/YYYY-MM-DD.md`, one file per account per day.
+
+Other flags:
+
+| Flag | What it does |
+| --- | --- |
+| `-d, --dir <path>` | Use a different impersonation root for this run |
+| `--migrate` | Normalise an existing tree to the current layout (see [Migrating](#migrating-an-existing-tree)) |
+| `--reset-settings` | Overwrite the shared permissions file from the plugin's template |
+| `-h, --help` | Usage |
+
+## Configuration
+
+Two optional knobs, and that's the whole surface. Everything else the audit needs (account slug, folder, audit filename) is derived per run from the name you pass — there is nothing to set per account.
+
+| Variable | Default | What it does |
+| --- | --- | --- |
+| `CSM_IMPERSONATE_HOME` | `~/impersonate` | Where per-account folders live |
+| `CSM_CUSTOMER_CONTEXT_DIR` | `~/Documents/Obsidian Vault/Customers` if that directory exists, otherwise unset | Where your own per-account notes live. The `account-audit` skill reads the matching account's notes before writing findings. **Leave it unset and the skill skips notes entirely** rather than hunting around your filesystem for a vault you don't have |
+
+Set them either in the config file, created (fully commented out) on first run at `${XDG_CONFIG_HOME:-~/.config}/impersonate-audit/config`:
+
+```bash
+CSM_IMPERSONATE_HOME="$HOME/work/impersonate"
+CSM_CUSTOMER_CONTEXT_DIR="$HOME/notes/customers"
+```
+
+...or by exporting them from your own env file (`csm.env`, `~/.zshrc`, whatever) — the environment wins over the config file, and `--dir` wins over both.
+
+## Migrating an existing tree
+
+If you were on 1.0.x you have `~/impersonate/Acme Inc/audit-2026-08-11.md` and a `.claude/settings.local.json` in every account folder. One command folds all of it into the current layout:
+
+```bash
+impersonate-audit --migrate
+```
+
+It renames folders to their slug form, drops the `audit-` prefix from audit files, and merges every per-account permissions file into the shared one at the root (so the approvals you granted in each folder carry over rather than being thrown away). It prompts first and skips anything that would collide. Running a normal audit for an account whose folder still has the old name offers the same rename for just that account.
+
 ## Security model
 
-The toolkit relies on two independent layers of defense — both have to fail for an unwanted mutation to land in a customer's account:
+An audit run through this toolkit is read-only, and that is enforced by PostHog, server-side, not by anything in this repo.
 
-1. **Impersonation token scope (server-side).** When you impersonate a user in Django Admin and select **read-only**, PostHog's OAuth authorization server downgrades every `:write` scope to `:read` before minting the access token. Even if a client requests broad scopes, the resulting token literally cannot write. This is enforced server-side, not by the client. Default to read-only impersonation; only escalate to read+write when you need to create something in the customer's account.
+The session uses the OAuth token minted from your read-only impersonation session. PostHog strips every write scope from that token before issuing it, and rejects any mutating request made with it. An audit can read a customer's project; it cannot change one. This toolkit mints no credentials of its own and can grant itself nothing.
 
-2. **Claude Code permission rules (client-side).** `assets/settings.local.json` is copied into every customer folder on each run as `.claude/settings.local.json`. It defines two lists:
+## Permissions file
 
-   - **`allow`** — auto-approved patterns. Strictly reads — list/get/retrieve/search/query/stats/counts/etc.
-   - **`ask`** — patterns that always prompt for explicit confirmation: updates, deletes, archives, creates (`*-create`, `create-*`), and `execute-sql`. The skill itself is read-only by design — creates and SQL are user-driven (e.g. spinning up an example experiment during a demo, or running an ad-hoc HogQL query), and require an explicit one-click approval each time. 7 specific exact-name overrides for destructive `*-create` tools (e.g. `feature-flags-bulk-delete-create`) remain even though the broad `*-create` pattern now covers them — they serve as documentation of the known-destructive set.
+Separate concern, and purely convenience: a PostHog account audit calls dozens of read tools, and without an allowlist each one stops for approval. `assets/settings.local.json` pre-approves the read tools so an audit runs start to finish, and leaves everything else to prompt normally.
 
-   Anything not matched by either list falls through to Claude Code's default behavior (prompt).
+It is merged into a single `.claude/settings.local.json` at the root of your impersonation tree. Claude launches at that root, so one file covers every account. Account folders are where output lands, not separate workspaces:
 
-The combination means: every mutative operation surfaces as a prompt before it fires (client-side defense), AND if a tool somehow slipped through, the read-only impersonation token rejects the write at the API layer (server-side defense). Both have to fail for an unwanted change to land.
+```
+~/impersonate/                    <- Claude runs here
+├── .claude/settings.local.json   <- the only permissions file
+├── acme-inc/2026-08-11.md
+└── initech-co/2026-08-13.md
+```
 
-Updates to the permission template ship via `claude plugin update`.
+Permissions are granted once. Anything you approve mid-session lands in that shared file and applies to every account from then on.
+
+Two consequences worth knowing:
+
+- Template updates are **merged**, not copied over the top, so `claude plugin update` can't wipe approvals you granted. Entries the template moves between `allow` and `ask` follow the template. Merging needs `jq`; without it an existing file is left untouched rather than clobbered. `--reset-settings` forces a clean copy from the template.
+- Every session's working directory contains every account's folder, so a session for one customer can read another customer's audit if you ask it to. If you'd rather each session only see one account, that's yours to arrange — point `--dir` at a per-account root, or make the impersonation root a git repo (Claude Code resolves project settings to the repo root, which lets you launch inside an account folder and still share one settings file). The wrapper follows an existing repo root if it finds one; it won't create one for you.
 
 ## Updating
 
@@ -82,7 +128,7 @@ Updates to the permission template ship via `claude plugin update`.
 claude plugin update
 ```
 
-The shim in `~/bin/impersonate-audit` always discovers the newest installed version — no manual re-symlinking needed.
+The shim in `~/bin/impersonate-audit` always discovers the newest installed version — no manual re-symlinking needed. It also nudges you (once a day, non-fatally) when the installed copy has gone stale, so you don't audit on a months-old playbook without noticing.
 
 ## File layout
 
@@ -92,16 +138,27 @@ impersonation-toolkit/
 ├── SKILL.md                          # Audit playbook — auto-triggers on "audit X's experiment"
 ├── README.md                         # This file
 ├── scripts/
-│   └── impersonate-audit.sh          # Wrapper invoked by ~/bin/impersonate-audit shim
+│   ├── impersonate-audit.sh          # Wrapper invoked by the ~/bin/impersonate-audit shim
+│   └── impersonate-audit-shim.sh     # The shim itself — copy it to ~/bin/impersonate-audit
 └── assets/
-    └── settings.local.json           # Permissions template, copied into each customer folder
+    └── settings.local.json           # Permissions template, merged into the shared settings file
+```
+
+And what it creates on your machine:
+
+```
+${XDG_CONFIG_HOME:-~/.config}/impersonate-audit/config   # your two optional knobs
+$CSM_IMPERSONATE_HOME/                                   # default ~/impersonate, where Claude runs
+├── .claude/settings.local.json                          # shared permissions
+└── <account-slug>/<YYYY-MM-DD>.md                       # one audit per account per day
 ```
 
 ## Caveats
 
 - The Django Admin impersonation step is intentionally manual (security boundary). The script can't bypass it.
 - The PostHog MCP plugin's tool-name prefix is assumed to be `mcp__plugin_posthog_posthog__*`. If permission rules don't seem to apply, run the first audit, watch for unexpected prompts on read tools, and check the actual tool names exposed via `/mcp`.
-- Permission template pattern coverage is broad but not exhaustive across all 300+ PostHog MCP tools. New tool names that don't follow conventional `-create` / `-update` / `-delete` suffixes will default to "ask" — safe, but you may get unexpected prompts. PR additions to `assets/settings.local.json` in this plugin's directory.
+- The read allowlist is broad but not exhaustive across all 300+ PostHog MCP tools, so a read tool with an unconventional name will still prompt. Harmless, just a bit of friction — PR additions to `assets/settings.local.json` in this plugin's directory.
+- Account slugs are derived from the name you type, so `InitechCo` and `Initech Co` are different folders (`initechco` vs `initech-co`). Stay consistent, or point at the existing folder with `--dir` if you split one by accident.
 
 ## Maintainer
 

--- a/skills/team/customer-success/impersonation-toolkit/SKILL.md
+++ b/skills/team/customer-success/impersonation-toolkit/SKILL.md
@@ -122,7 +122,7 @@ fix that unblocks the experiment?]
 
 ## Rules
 
-- **Read-only.** Do not create insights, dashboards, actions, experiments, or modify any config. You are impersonating the customer's user — any writes land in their actual project.
+- **Read-only.** Do not create insights, dashboards, actions, experiments, or modify any config. You are working inside a customer's project under read-only impersonation; treat it as look-but-don't-touch.
 - **No fabrication.** If you can't find the experiment or the data is empty, say so explicitly. Do not invent findings to fill the template.
 - **Cite real numbers.** Every claim about exposure counts, sample ratios, or event volumes must come from a query you actually ran in this session.
 - **Surface ambiguity.** If a setting could be intentional (e.g. low conversion window because conversion happens fast), note both interpretations and ask the customer to confirm.

--- a/skills/team/customer-success/impersonation-toolkit/scripts/impersonate-audit-shim.sh
+++ b/skills/team/customer-success/impersonation-toolkit/scripts/impersonate-audit-shim.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Launcher for the impersonation-toolkit plugin's wrapper script.
+#
+# Two independent checks, so a stale copy never gets reported as a missing one:
+#   1. installed?  hard error, tells you how to install
+#   2. fresh?      warning only (at most once per window), tells you how to update
+#
+# Knobs:
+#   CSM_IMPERSONATE_STALE_DAYS   warn when the plugin cache is older than this
+#                                many days (default 1; 0 or empty disables)
+
+set -euo pipefail
+
+CACHE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/cache/PostHog-skills/impersonation-toolkit"
+STALE_DAYS="${CSM_IMPERSONATE_STALE_DAYS-1}"
+STAMP="${XDG_STATE_HOME:-$HOME/.local/state}/impersonate-audit/last-stale-warning"
+
+mtime_of() {
+  stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null
+}
+
+days_since() {
+  local mtime
+  mtime="$(mtime_of "$1")" || return 1
+  [[ -n "$mtime" ]] || return 1
+  echo $(( ( $(date +%s) - mtime ) / 86400 ))
+}
+
+# 1. Is it installed?
+LATEST=""
+if [[ -d "$CACHE_DIR" ]]; then
+  LATEST="$(find "$CACHE_DIR" -mindepth 1 -maxdepth 1 -type d | sort -V | tail -1)"
+fi
+
+if [[ -z "$LATEST" ]]; then
+  echo "impersonation-toolkit is not installed." >&2
+  echo "  Inside Claude Code:" >&2
+  echo "    /plugin marketplace add PostHog/skills" >&2
+  echo "    /plugin install impersonation-toolkit@PostHog-skills" >&2
+  exit 1
+fi
+
+SCRIPT="$LATEST/scripts/impersonate-audit.sh"
+if [[ ! -f "$SCRIPT" ]]; then
+  echo "impersonation-toolkit $(basename "$LATEST") is installed but has no wrapper script." >&2
+  echo "  Expected: $SCRIPT" >&2
+  echo "  Reinstall with: /plugin install impersonation-toolkit@PostHog-skills" >&2
+  exit 1
+fi
+
+# 2. Is it fresh? Never fatal — you can always run an older copy.
+if [[ -n "$STALE_DAYS" && "$STALE_DAYS" != "0" ]]; then
+  age="$(days_since "$LATEST" || echo 0)"
+  warn_age="$(days_since "$STAMP" 2>/dev/null || echo "")"
+  if (( age > STALE_DAYS )) && [[ -z "$warn_age" || "$warn_age" -gt "$STALE_DAYS" ]]; then
+    echo "⚠️  impersonation-toolkit $(basename "$LATEST") was installed ${age} day(s) ago." >&2
+    echo "    Run '/plugin update' inside Claude Code if you want the latest playbook." >&2
+    echo "    (Silence this with CSM_IMPERSONATE_STALE_DAYS=0.)" >&2
+    echo >&2
+    mkdir -p "$(dirname "$STAMP")"
+    touch "$STAMP"
+  fi
+fi
+
+exec "$SCRIPT" "$@"

--- a/skills/team/customer-success/impersonation-toolkit/scripts/impersonate-audit.sh
+++ b/skills/team/customer-success/impersonation-toolkit/scripts/impersonate-audit.sh
@@ -469,8 +469,14 @@ STEP 2: Re-authenticate the posthog plugin in Claude Code
     (audit output lands in $ACCOUNT_SLUG/)
   - Inside Claude Code, type:  /mcp
   - Find 'posthog' → "Clear authentication" → then "Authenticate"
-  - A browser tab opens; it'll pick up your active impersonation session
-    and bind a fresh token. Takes ~10 seconds.
+  - A browser tab opens with the PostHog OAuth consent screen. Pick:
+      · Scope:        read-only  (an audit reads; it never writes)
+      · Organization: the customer's org
+      · Project:      the customer's project
+    Your Django impersonation session already scopes the token read-only
+    regardless of what you click here — the point is to avoid building
+    muscle memory of granting write scopes while impersonating.
+  - Takes ~10 seconds.
   - Sanity check: ask Claude "what project am I in?" — you should see
     the customer's project, NOT 'PostHog App + Website' (id 2). If you
     see project 2, the impersonation didn't carry — repeat /mcp re-auth

--- a/skills/team/customer-success/impersonation-toolkit/scripts/impersonate-audit.sh
+++ b/skills/team/customer-success/impersonation-toolkit/scripts/impersonate-audit.sh
@@ -8,25 +8,46 @@
 # impersonation session, runs the audit, and reminds you to clean up.
 #
 # Usage:
-#   impersonate-audit.sh <customer-slug>
+#   impersonate-audit.sh [options] <account name>
+#
+# Options:
+#   -d, --dir <path>     Override the impersonation root for this run
+#       --migrate        Normalise existing folders/files to the current layout
+#       --reset-settings Overwrite the shared permissions file from the template
+#   -h, --help           Show usage
+#
+# Configuration (first match wins):
+#   --dir flag  >  $CSM_IMPERSONATE_HOME  >  config file  >  ~/impersonate
+#
+# Every knob is CSM_-prefixed, so you can keep them in your own env file
+# (csm.env, ~/.zshrc, whatever) instead of the config file. Defaults reproduce
+# the behaviour this script had before these knobs existed:
+#   CSM_IMPERSONATE_HOME        default ~/impersonate
+#   CSM_CUSTOMER_CONTEXT_DIR    default ~/Documents/Obsidian Vault/Customers,
+#                               used only if that directory actually exists
+#   CSM_IMPERSONATE_CONFIG      default ${XDG_CONFIG_HOME:-~/.config}/impersonate-audit/config
+#
+# The config file is created (fully commented out) on first run.
+#
+# Layout — Claude runs at the root, so one settings file covers every account:
+#   $CSM_IMPERSONATE_HOME/                 working directory for every session
+#   ├── .claude/settings.local.json        shared permissions, merged not clobbered
+#   └── <account-slug>/YYYY-MM-DD.md       one audit per account per day
 #
 # Flow:
-#   1. Create ~/impersonate/<customer-slug>/ (a place for notes/exports)
+#   1. Resolve config, slugify the account name, create its folder
 #   2. Remind you to impersonate the customer's user in Django Admin (manual)
 #   3. Remind you to /mcp re-auth the posthog plugin inside Claude Code
-#   4. Launch `claude` in the folder
+#   4. Launch `claude` at the root, with the account's folder ready for output
 #   5. On Claude exit, print cleanup reminders
 
 set -euo pipefail
 
-CUSTOMER="${1:-}"
-if [[ -z "$CUSTOMER" ]]; then
-  echo "Usage: $(basename "$0") <customer-slug>" >&2
-  echo "Example: $(basename "$0") givebutter" >&2
-  exit 1
-fi
+CONFIG_FILE="${CSM_IMPERSONATE_CONFIG:-${XDG_CONFIG_HOME:-$HOME/.config}/impersonate-audit/config}"
 
-DIR="$HOME/impersonate/$CUSTOMER"
+# Where per-account notes lived before this was configurable. Still the default,
+# but only honoured if the directory is actually there.
+DEFAULT_CONTEXT_DIR="$HOME/Documents/Obsidian Vault/Customers"
 
 # The settings template ships alongside this script inside the plugin.
 # $BASH_SOURCE resolves to the actual script path (the shim in ~/bin/
@@ -35,32 +56,406 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 TEMPLATE_FILE="$PLUGIN_DIR/assets/settings.local.json"
 
-mkdir -p "$DIR"
-cd "$DIR"
+usage() {
+  cat <<'EOF'
+Usage: impersonate-audit [options] <account name>
 
-# Refresh per-folder permission rules from the plugin's template every run,
-# so plugin updates (`claude plugin update`) propagate to every customer
-# folder on next launch.
-if [[ -f "$TEMPLATE_FILE" ]]; then
-  mkdir -p "$DIR/.claude"
-  cp -f "$TEMPLATE_FILE" "$DIR/.claude/settings.local.json"
-else
-  echo "⚠️  Settings template not found at $TEMPLATE_FILE — skipping permissions setup." >&2
+  impersonate-audit globex
+  impersonate-audit "Acme Inc"          -> ~/impersonate/acme-inc/
+  impersonate-audit --dir ~/work/audits acme
+
+Options:
+  -d, --dir <path>     Impersonation root for this run (overrides config + env)
+      --migrate        Normalise existing folders/files to the current layout
+      --reset-settings Overwrite the shared permissions file from the template
+  -h, --help           Show this help
+
+Config file: ${XDG_CONFIG_HOME:-~/.config}/impersonate-audit/config
+Anything you export in your own env file (csm.env, ~/.zshrc, ...) wins over it:
+  CSM_IMPERSONATE_HOME=...       account folders live here (default ~/impersonate)
+  CSM_CUSTOMER_CONTEXT_DIR=...   your per-account notes live here (default
+                                 ~/Documents/Obsidian Vault/Customers if present,
+                                 otherwise the notes step is skipped)
+EOF
+}
+
+# ---------------------------------------------------------------- arguments
+
+CLI_HOME=""
+MODE="run"
+RESET_SETTINGS=0
+POSITIONAL=()
+
+while (($#)); do
+  case "$1" in
+    -d|--dir)
+      if [[ -z "${2:-}" ]]; then
+        echo "Error: --dir needs a path" >&2
+        exit 1
+      fi
+      CLI_HOME="$2"
+      shift 2
+      ;;
+    --migrate)
+      MODE="migrate"
+      shift
+      ;;
+    --reset-settings)
+      RESET_SETTINGS=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      while (($#)); do
+        POSITIONAL+=("$1")
+        shift
+      done
+      ;;
+    -*)
+      echo "Error: unknown option '$1'" >&2
+      usage >&2
+      exit 1
+      ;;
+    *)
+      POSITIONAL+=("$1")
+      shift
+      ;;
+  esac
+done
+
+# Unquoted multi-word names ("Acme Inc") arrive as separate arguments — join
+# them back so you don't have to remember the quotes.
+ACCOUNT_NAME=""
+if ((${#POSITIONAL[@]})); then
+  ACCOUNT_NAME="${POSITIONAL[*]}"
 fi
+
+# ------------------------------------------------------------------- config
+
+# Env wins over the config file, so snapshot it before sourcing.
+ENV_HOME="${CSM_IMPERSONATE_HOME:-}"
+ENV_CONTEXT_DIR="${CSM_CUSTOMER_CONTEXT_DIR:-}"
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  mkdir -p "$(dirname "$CONFIG_FILE")"
+  cat > "$CONFIG_FILE" <<'EOF'
+# impersonate-audit configuration — plain KEY=VALUE, sourced by the wrapper.
+# Uncomment and edit what you want to change. Anything exported in your shell
+# (csm.env, ~/.zshrc, ...) wins over this file.
+
+# Where per-account impersonation folders live.
+# CSM_IMPERSONATE_HOME="$HOME/impersonate"
+
+# Where your per-account notes live, if you keep any. The audit skill reads the
+# matching account's notes from here before writing findings.
+# Defaults to "$HOME/Documents/Obsidian Vault/Customers" when that directory
+# exists. If it doesn't and you don't set this, the skill skips notes entirely
+# rather than hunting around your filesystem.
+# CSM_CUSTOMER_CONTEXT_DIR="$HOME/notes/customers"
+EOF
+  echo "Created config: $CONFIG_FILE"
+fi
+
+# shellcheck source=/dev/null
+source "$CONFIG_FILE"
+
+if [[ -n "$ENV_HOME" ]]; then
+  CSM_IMPERSONATE_HOME="$ENV_HOME"
+fi
+if [[ -n "$CLI_HOME" ]]; then
+  CSM_IMPERSONATE_HOME="$CLI_HOME"
+fi
+if [[ -n "$ENV_CONTEXT_DIR" ]]; then
+  CSM_CUSTOMER_CONTEXT_DIR="$ENV_CONTEXT_DIR"
+fi
+
+CSM_IMPERSONATE_HOME="${CSM_IMPERSONATE_HOME:-$HOME/impersonate}"
+CSM_IMPERSONATE_HOME="${CSM_IMPERSONATE_HOME%/}"
+
+# Unset falls back to the old Obsidian location, but only when it's really
+# there — otherwise it stays empty and the skill skips the notes step.
+CSM_CUSTOMER_CONTEXT_DIR="${CSM_CUSTOMER_CONTEXT_DIR:-}"
+if [[ -z "$CSM_CUSTOMER_CONTEXT_DIR" && -d "$DEFAULT_CONTEXT_DIR" ]]; then
+  CSM_CUSTOMER_CONTEXT_DIR="$DEFAULT_CONTEXT_DIR"
+fi
+CSM_CUSTOMER_CONTEXT_DIR="${CSM_CUSTOMER_CONTEXT_DIR%/}"
+
+if [[ "$CSM_IMPERSONATE_HOME" == "$HOME" ]]; then
+  echo "Error: CSM_IMPERSONATE_HOME cannot be your home directory." >&2
+  echo "       Claude Code won't share one settings file from there. Pick a subfolder." >&2
+  exit 1
+fi
+
+# ----------------------------------------------------------------- helpers
+
+# Lowercase; accents folded to their base letter; every run of non-alphanumeric
+# characters becomes a single hyphen. "Café Söda, Inc." -> cafe-soda-inc
+slugify() {
+  local s="$1" folded
+
+  # Decompose then drop the combining marks (macOS); fall back to iconv's own
+  # transliteration (glibc); fall back to leaving the string alone.
+  if folded="$(printf '%s' "$s" | iconv -f UTF-8 -t UTF-8-MAC 2>/dev/null | LC_ALL=C sed $'s/[\xcc\xcd][\x80-\xbf]//g')" && [[ -n "$folded" ]]; then
+    s="$folded"
+  elif folded="$(printf '%s' "$s" | iconv -f UTF-8 -t ASCII//TRANSLIT 2>/dev/null)" && [[ -n "$folded" ]]; then
+    s="$folded"
+  fi
+
+  printf '%s' "$s" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//'
+}
+
+# Merge $1 (template or legacy settings) into $2, preserving anything Claude
+# Code learned in $2. Entries the template moved between allow/ask follow the
+# template. Without jq we leave an existing file alone rather than clobber it.
+merge_settings() {
+  local src="$1" dst="$2" tmp
+
+  if [[ ! -f "$src" ]]; then
+    return 1
+  fi
+
+  mkdir -p "$(dirname "$dst")"
+
+  if [[ ! -f "$dst" ]]; then
+    cp "$src" "$dst"
+    return 0
+  fi
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "⚠️  jq not found — leaving $dst as-is. Use --reset-settings to overwrite it." >&2
+    return 0
+  fi
+
+  tmp="$(mktemp "${dst}.XXXXXX")"
+  if jq -s '
+        .[0] as $tpl | .[1] as $cur
+        | (($cur.permissions.allow // []) - ($tpl.permissions.ask   // []) + ($tpl.permissions.allow // []) | unique) as $allow
+        | (($cur.permissions.ask   // []) - ($tpl.permissions.allow // []) + ($tpl.permissions.ask   // []) | unique) as $ask
+        | $cur * { permissions: (($cur.permissions // {}) + { allow: $allow, ask: $ask }) }
+      ' "$src" "$dst" > "$tmp"; then
+    mv "$tmp" "$dst"
+  else
+    rm -f "$tmp"
+    echo "⚠️  Could not merge permissions into $dst (invalid JSON?). Left untouched." >&2
+  fi
+}
+
+confirm() {
+  local answer
+  read -r -p "$1 [y/N] " answer
+  [[ "$answer" =~ ^[Yy] ]]
+}
+
+# Rename $1 to $2. Returns 2 on a genuine collision. On case-insensitive
+# filesystems "InitechCo" and "initechco" are the same path, so a case-only
+# rename has to bounce through a temporary name.
+rename_path() {
+  local from="$1" to="$2" tmp
+  if [[ "$from" == "$to" ]]; then
+    return 0
+  fi
+  if [[ -e "$to" ]]; then
+    if [[ ! "$from" -ef "$to" ]]; then
+      return 2
+    fi
+    tmp="${from}.rename-$$"
+    mv "$from" "$tmp"
+    mv "$tmp" "$to"
+    return 0
+  fi
+  mv "$from" "$to"
+}
+
+# ------------------------------------------------------------ settings root
+
+# Claude launches at the impersonation root, so one .claude/settings.local.json
+# there covers every account — including the permissions you approve
+# mid-session. Account folders are output, not workspaces.
+#
+# One wrinkle: if the root sits inside a git repo (someone keeping audits in
+# their notes repo, say), Claude Code resolves project settings to that repo's
+# root instead. Follow it rather than writing a file that would be ignored.
+SETTINGS_ROOT="$CSM_IMPERSONATE_HOME"
+GIT_TOP=""
+
+mkdir -p "$CSM_IMPERSONATE_HOME"
+
+if command -v git >/dev/null 2>&1; then
+  if GIT_TOP="$(git -C "$CSM_IMPERSONATE_HOME" rev-parse --show-toplevel 2>/dev/null)" \
+     && [[ -n "$GIT_TOP" && "$GIT_TOP" != "$HOME" ]]; then
+    SETTINGS_ROOT="$GIT_TOP"
+  fi
+fi
+
+# ---------------------------------------------------------------- migration
+
+# Fold a legacy layout into the current one: "Acme Inc" -> acme-inc,
+# audit-2026-08-11.md -> 2026-08-11.md, per-account permissions -> shared file.
+migrate_all() {
+  local entry base slug target legacy_settings moved=0 renamed=0 folded=0
+
+  shopt -s nullglob
+  for entry in "$CSM_IMPERSONATE_HOME"/*/; do
+    entry="${entry%/}"
+    base="$(basename "$entry")"
+    [[ "$base" == ".claude" ]] && continue
+    slug="$(slugify "$base")"
+    target="$CSM_IMPERSONATE_HOME/$slug"
+
+    if [[ "$base" != "$slug" ]]; then
+      if rename_path "$entry" "$target"; then
+        echo "  move  $base -> $slug"
+        entry="$target"
+        moved=$((moved + 1))
+      else
+        echo "  skip  $base -> $slug (a different folder already uses that name)"
+      fi
+    fi
+
+    local audit
+    for audit in "$entry"/audit-*.md; do
+      local newname
+      newname="$(basename "$audit")"
+      newname="${newname#audit-}"
+      if rename_path "$audit" "$entry/$newname"; then
+        echo "  file  $(basename "$entry")/$(basename "$audit") -> $newname"
+        renamed=$((renamed + 1))
+      else
+        echo "  skip  $(basename "$audit") -> $newname (target already exists)"
+      fi
+    done
+
+    legacy_settings="$entry/.claude/settings.local.json"
+    if [[ -n "$SETTINGS_ROOT" && -f "$legacy_settings" && "$entry" != "$SETTINGS_ROOT" ]]; then
+      merge_settings "$legacy_settings" "$SETTINGS_ROOT/.claude/settings.local.json"
+      rm -f "$legacy_settings"
+      rmdir "$entry/.claude" 2>/dev/null || true
+      echo "  perms $(basename "$entry")/.claude/settings.local.json -> shared file"
+      folded=$((folded + 1))
+    fi
+  done
+  shopt -u nullglob
+
+  echo
+  echo "Migrated: $moved folder(s) renamed, $renamed audit file(s) renamed, $folded permissions file(s) folded in."
+}
+
+if [[ "$MODE" == "migrate" ]]; then
+  echo "Migrating $CSM_IMPERSONATE_HOME to the current layout."
+  echo "Folders become lowercase-hyphenated, audit-<date>.md becomes <date>.md, and"
+  echo "per-account permissions merge into the shared file at the root."
+  echo
+  if confirm "Proceed?"; then
+    migrate_all
+  else
+    echo "Nothing changed."
+  fi
+  exit 0
+fi
+
+# --------------------------------------------------------------- run set-up
+
+if [[ -z "$ACCOUNT_NAME" ]]; then
+  usage >&2
+  exit 1
+fi
+
+ACCOUNT_SLUG="$(slugify "$ACCOUNT_NAME")"
+if [[ -z "$ACCOUNT_SLUG" ]]; then
+  echo "Error: '$ACCOUNT_NAME' has no usable characters for a folder name." >&2
+  exit 1
+fi
+
+ACCOUNT_DIR="$CSM_IMPERSONATE_HOME/$ACCOUNT_SLUG"
+
+# Offer to pick up a pre-slug folder for this same account rather than starting
+# an empty one next to it. Case-only differences count: on a case-insensitive
+# filesystem "InitechCo" already answers to "initechco", but the folder still
+# shows up mixed-case until it's renamed.
+shopt -s nullglob
+for candidate in "$CSM_IMPERSONATE_HOME"/*/; do
+  candidate="${candidate%/}"
+  if [[ "$(basename "$candidate")" != "$ACCOUNT_SLUG" && "$(slugify "$(basename "$candidate")")" == "$ACCOUNT_SLUG" ]]; then
+    echo "Found an older folder for this account: $(basename "$candidate")"
+    if confirm "Rename it to '$ACCOUNT_SLUG'?"; then
+      if rename_path "$candidate" "$ACCOUNT_DIR"; then
+        echo "Renamed. (Run --migrate to normalise every other account too.)"
+      else
+        echo "⚠️  A different folder already uses '$ACCOUNT_SLUG' — left as-is." >&2
+      fi
+    fi
+    break
+  fi
+done
+shopt -u nullglob
+
+mkdir -p "$ACCOUNT_DIR"
+
+SETTINGS_FILE="$SETTINGS_ROOT/.claude/settings.local.json"
+
+# A leftover per-account permissions file from the old layout is dead weight now
+# that settings live at the root — fold whatever it learned into the shared
+# file so those approvals aren't lost, then get rid of it.
+LEGACY_SETTINGS="$ACCOUNT_DIR/.claude/settings.local.json"
+if [[ "$SETTINGS_ROOT" != "$ACCOUNT_DIR" && -f "$LEGACY_SETTINGS" ]]; then
+  merge_settings "$LEGACY_SETTINGS" "$SETTINGS_FILE"
+  rm -f "$LEGACY_SETTINGS"
+  rmdir "$ACCOUNT_DIR/.claude" 2>/dev/null || true
+  echo "Folded this account's old permissions file into the shared one."
+fi
+
+if [[ ! -f "$TEMPLATE_FILE" ]]; then
+  echo "⚠️  Settings template not found at $TEMPLATE_FILE — skipping permissions setup." >&2
+elif ((RESET_SETTINGS)); then
+  mkdir -p "$(dirname "$SETTINGS_FILE")"
+  cp -f "$TEMPLATE_FILE" "$SETTINGS_FILE"
+  echo "Permissions reset from the plugin template: $SETTINGS_FILE"
+else
+  merge_settings "$TEMPLATE_FILE" "$SETTINGS_FILE"
+fi
+
+AUDIT_FILE="$ACCOUNT_DIR/$(date +%Y-%m-%d).md"
+
+# Derived from the account name you passed — none of these are yours to set.
+# The audit skill reads them instead of guessing paths or searching for notes.
+export CSM_IMPERSONATE_HOME
+export CSM_IMPERSONATE_ACCOUNT="$ACCOUNT_SLUG"
+export CSM_IMPERSONATE_ACCOUNT_NAME="$ACCOUNT_NAME"
+export CSM_IMPERSONATE_ACCOUNT_DIR="$ACCOUNT_DIR"
+export CSM_IMPERSONATE_AUDIT_FILE="$AUDIT_FILE"
+export CSM_CUSTOMER_CONTEXT_DIR
+
+cd "$CSM_IMPERSONATE_HOME"
 
 cat <<EOF
 
 ============================================================
-  Impersonation audit — $CUSTOMER
-  Folder: $DIR  (use it for notes, exports, scratch files)
+  Impersonation audit — $ACCOUNT_NAME
+  Working dir: $CSM_IMPERSONATE_HOME
+  Folder:      $ACCOUNT_SLUG/  (notes, exports, scratch files)
+  Audit:       $ACCOUNT_SLUG/$(basename "$AUDIT_FILE")
+  Perms:       $SETTINGS_FILE
+EOF
+
+if [[ -n "$CSM_CUSTOMER_CONTEXT_DIR" ]]; then
+  echo "  Notes:       $CSM_CUSTOMER_CONTEXT_DIR"
+fi
+
+cat <<EOF
 ============================================================
 
 STEP 1: Impersonate the customer's user in Django Admin
   - Open PostHog Django Admin in your browser
-  - Find the user → click "Impersonate" → select read-only scope
-    (read+write is only needed if you'll create something in their account
-    during the audit — e.g. an example experiment or dashboard. Default
-    to read-only.)
+  - Find the user → click "Impersonate" → give a reason
+  - Read-only is the default and is what an audit needs. PostHog strips
+    write scopes from the token it mints and rejects mutating requests,
+    so nothing this session does can change their project.
   - Keep that browser tab open through the whole audit
 
 EOF
@@ -70,7 +465,8 @@ read -r -p "Press enter once impersonation is active in your browser..." _
 cat <<EOF
 
 STEP 2: Re-authenticate the posthog plugin in Claude Code
-  - I'll launch Claude in this folder next
+  - I'll launch Claude next, in $CSM_IMPERSONATE_HOME
+    (audit output lands in $ACCOUNT_SLUG/)
   - Inside Claude Code, type:  /mcp
   - Find 'posthog' → "Clear authentication" → then "Authenticate"
   - A browser tab opens; it'll pick up your active impersonation session
@@ -82,8 +478,10 @@ STEP 2: Re-authenticate the posthog plugin in Claude Code
 
 STEP 3: Run the audit
   - Once the project check passes, just say:
-      "audit <customer>'s experiment named '<experiment name>'"
-  - The experiment-audit skill auto-loads and runs the playbook.
+      "audit $ACCOUNT_NAME's experiment named '<experiment name>'"
+    or, for the whole instance:
+      "run an account audit on $ACCOUNT_NAME"
+  - The audit skill auto-loads and runs the playbook.
 
 EOF
 
@@ -100,6 +498,11 @@ echo "============================================================"
 echo "  Teardown"
 echo "============================================================"
 echo
+
+if [[ -f "$AUDIT_FILE" ]]; then
+  echo "📄 Audit written to $AUDIT_FILE"
+  echo
+fi
 
 PLUGIN_STATUS=$(claude mcp list 2>/dev/null | grep "plugin:posthog" | head -1 || true)
 


### PR DESCRIPTION
some "QoL tweaks" to this Claude plugin...

* let users specify where the audits should live, defaults to `$HOME/impersonate`
* let users specify where account context lives, defaults to `$HOME/Documents/Obsidian Vault/Customers`
* instead of generating a per account `settings.json` file, generate one to govern all of them. this is made easier by the fact that PostHog won't mint a token for anything but read scopes. adds convenience by not needing to approve commands constantly.
* adds a cheap "freshness" mechanism to the script to auto prompt users to update the plugin
* provides a migration path to update from 1.0.1
* slugify and "kebab-case" account names (also accounting for diacritics and other ASCII characters)
* if inside a git repo, checks for and handles inheritance with an existing `settings.json`
* `shellcheck` against scripts exits `0` and emits no output