### PR TITLE
impersonation-toolkit: refusal protocol + refusals.log + debug.log

### DIFF
--- a/skills/team/customer-success/impersonation-toolkit/README.md
+++ b/skills/team/customer-success/impersonation-toolkit/README.md
@@ -142,7 +142,8 @@ impersonation-toolkit/
 ├── README.md                         # This file
 ├── scripts/
 │   ├── impersonate-audit.sh          # Wrapper invoked by the ~/bin/impersonate-audit shim
-│   └── impersonate-audit-shim.sh     # The shim itself — copy it to ~/bin/impersonate-audit
+│   ├── impersonate-audit-shim.sh     # The shim itself — copy it to ~/bin/impersonate-audit
+│   └── redact.sh                     # Deterministic token redactor for the two logs
 └── assets/
     └── settings.local.json           # Permissions template, merged into the shared settings file
 ```
@@ -184,7 +185,9 @@ SID="$(jq -r 'select(.reason_code == "mcp_auth_expired") | .session_id' \
 jq -c "select(.session_id == \"$SID\")" ~/.local/state/impersonate-audit/debug.log
 ```
 
-Reason codes: `wrong_project`, `empty_project`, `mcp_disconnected`, `mcp_auth_expired`, `switch_project_failed`, `experiment_not_found`, `no_exposure_data`, `tool_call_error`, `other`. See `SKILL.md` for the exact discriminator on each.
+Reason codes: `wrong_project`, `empty_project`, `mcp_disconnected`, `mcp_auth_expired`, `switch_project_failed`, `experiment_not_found`, `tool_call_error`, `other`. See `SKILL.md` for the exact discriminator on each. (A query that returns *zero rows* is an audit finding, not a refusal — Step 3 of the playbook diagnoses that.)
+
+Redaction is done by `scripts/redact.sh` — a small Perl script the wrapper points the skill at via `$CSM_IMPERSONATE_REDACT`. It runs outside the LLM, so a prompt-injected MCP error body can't talk the skill into skipping it. Every free-text field in either log is piped through the script before write. Patterns covered: `Bearer` tokens, PostHog `phc_/phx_/phs_/sTOK_` prefixes, JWTs, cookie/set-cookie header values, and any 24+ char base64url blob (catch-all for OAuth codes and unknown token shapes).
 
 ## Caveats
 

--- a/skills/team/customer-success/impersonation-toolkit/README.md
+++ b/skills/team/customer-success/impersonation-toolkit/README.md
@@ -189,7 +189,7 @@ Reason codes: `wrong_project`, `empty_project`, `mcp_disconnected`, `mcp_auth_ex
 
 Redaction is done by `scripts/redact.sh` — a small Perl script the wrapper points the skill at via `$CSM_IMPERSONATE_REDACT`. It runs outside the LLM, so a prompt-injected MCP error body can't talk the skill into skipping it. Every free-text field in either log — plus the human-readable refusal in the audit `.md` file — is piped through the script before write.
 
-Patterns covered: `Bearer` tokens, PostHog `phc_/phx_/phs_/sTOK_` prefixes, JWTs (`eyJ<hdr>.<pld>.<sig>`), cookie / set-cookie header values, and framed secrets (a keyword like `token`, `code`, `authorization`, `secret`, `api_key` followed by `:` / `=` / whitespace and a token-shaped value). Each rule names the shape it redacts; there's no length-based catch-all because that pattern ate legitimate identifiers. When a new token shape shows up, add a named rule for it and regen `scripts/redact-test.sh` with a case.
+Patterns covered: `Bearer` tokens, PostHog `phc_/phx_/phs_/sTOK_` prefixes, JWTs (`eyJ<hdr>.<pld>.<sig>`), cookie / set-cookie header values, and framed secrets (a keyword like `token`, `code`, `authorization`, `secret`, `api_key` followed by `:` / `=` / whitespace and a token-shaped value). Each rule names the shape it redacts; there's no length-based catch-all because that pattern ate legitimate identifiers. When a new token shape shows up, add a named rule to `scripts/redact.sh` and add a matching case to `scripts/redact-test.sh` so the pattern is regression-tested.
 
 ## Caveats
 

--- a/skills/team/customer-success/impersonation-toolkit/README.md
+++ b/skills/team/customer-success/impersonation-toolkit/README.md
@@ -150,11 +150,41 @@ impersonation-toolkit/
 And what it creates on your machine:
 
 ```
-${XDG_CONFIG_HOME:-~/.config}/impersonate-audit/config   # your two optional knobs
+${XDG_CONFIG_HOME:-~/.config}/impersonate-audit/config      # your two optional knobs
+${XDG_STATE_HOME:-~/.local/state}/impersonate-audit/
+├── refusals.log                                         # one JSONL entry per refused audit
+└── debug.log                                            # raw MCP errors, joinable to refusals.log by session_id
 $CSM_IMPERSONATE_HOME/                                   # default ~/impersonate, where Claude runs
 ├── .claude/settings.local.json                          # shared permissions
 └── <account-slug>/<YYYY-MM-DD>.md                       # one audit per account per day
 ```
+
+## Debugging failed audits
+
+When the skill can't complete an audit — wrong MCP project, disconnected MCP, missing experiment, empty data — it refuses explicitly instead of falling back to producing prompts for you to paste elsewhere. Two logs get you the full picture:
+
+- **`refusals.log`** — one JSONL entry per refused audit. Structured summary: account, timestamp, reason_code, what was tried, how to fix. This is the log to scan first.
+- **`debug.log`** — verbose companion. Raw MCP error responses, tool names, HTTP statuses, and error classes. Token-shaped strings are redacted before write. Cross-reference via `session_id` (also printed in the launch banner).
+
+Both live under `${XDG_STATE_HOME:-~/.local/state}/impersonate-audit/`. Neither rotates automatically; move old files aside when they get big.
+
+```bash
+# most recent refusals
+jq -c . ~/.local/state/impersonate-audit/refusals.log | tail
+
+# refusals for one account
+jq -c 'select(.account == "acme-inc")' ~/.local/state/impersonate-audit/refusals.log
+
+# count by reason
+jq -r .reason_code ~/.local/state/impersonate-audit/refusals.log | sort | uniq -c | sort -rn
+
+# pull the full raw-error trail for the most recent auth-expired refusal
+SID="$(jq -r 'select(.reason_code == "mcp_auth_expired") | .session_id' \
+       ~/.local/state/impersonate-audit/refusals.log | tail -1)"
+jq -c "select(.session_id == \"$SID\")" ~/.local/state/impersonate-audit/debug.log
+```
+
+Reason codes: `wrong_project`, `empty_project`, `mcp_disconnected`, `mcp_auth_expired`, `switch_project_failed`, `experiment_not_found`, `no_exposure_data`, `tool_call_error`, `other`. See `SKILL.md` for the exact discriminator on each.
 
 ## Caveats
 

--- a/skills/team/customer-success/impersonation-toolkit/README.md
+++ b/skills/team/customer-success/impersonation-toolkit/README.md
@@ -187,7 +187,9 @@ jq -c "select(.session_id == \"$SID\")" ~/.local/state/impersonate-audit/debug.l
 
 Reason codes: `wrong_project`, `empty_project`, `mcp_disconnected`, `mcp_auth_expired`, `switch_project_failed`, `experiment_not_found`, `tool_call_error`, `other`. See `SKILL.md` for the exact discriminator on each. (A query that returns *zero rows* is an audit finding, not a refusal — Step 3 of the playbook diagnoses that.)
 
-Redaction is done by `scripts/redact.sh` — a small Perl script the wrapper points the skill at via `$CSM_IMPERSONATE_REDACT`. It runs outside the LLM, so a prompt-injected MCP error body can't talk the skill into skipping it. Every free-text field in either log is piped through the script before write. Patterns covered: `Bearer` tokens, PostHog `phc_/phx_/phs_/sTOK_` prefixes, JWTs, cookie/set-cookie header values, and any 24+ char base64url blob (catch-all for OAuth codes and unknown token shapes).
+Redaction is done by `scripts/redact.sh` — a small Perl script the wrapper points the skill at via `$CSM_IMPERSONATE_REDACT`. It runs outside the LLM, so a prompt-injected MCP error body can't talk the skill into skipping it. Every free-text field in either log — plus the human-readable refusal in the audit `.md` file — is piped through the script before write.
+
+Patterns covered: `Bearer` tokens, PostHog `phc_/phx_/phs_/sTOK_` prefixes, JWTs (`eyJ<hdr>.<pld>.<sig>`), cookie / set-cookie header values, and framed secrets (a keyword like `token`, `code`, `authorization`, `secret`, `api_key` followed by `:` / `=` / whitespace and a token-shaped value). Each rule names the shape it redacts; there's no length-based catch-all because that pattern ate legitimate identifiers. When a new token shape shows up, add a named rule for it and regen `scripts/redact-test.sh` with a case.
 
 ## Caveats
 

--- a/skills/team/customer-success/impersonation-toolkit/SKILL.md
+++ b/skills/team/customer-success/impersonation-toolkit/SKILL.md
@@ -13,7 +13,116 @@ The skill assumes the active PostHog MCP is scoped to the **customer's** project
 
 > "What project am I in? List the most recent 5 experiments."
 
-If the project name looks like your own internal project (e.g. "PostHog App + Website", id 2), STOP — the impersonation isn't routing correctly. Re-run the wizard or check `/mcp` auth before continuing.
+Interpret the answer:
+
+- **Customer's project.** Proceed to Step 1.
+- **Your own internal project** (typically "PostHog App + Website", id 2). The impersonation session isn't routing. Refuse per the Refusal protocol. Do not proceed.
+- **MCP call fails outright** (no response, auth error, tool unavailable). Refuse per the Refusal protocol. Do not proceed.
+
+## Refusal protocol
+
+If any structural condition prevents you from actually auditing the customer's project, refuse explicitly and stop. Do **not** fall back to any of these anti-patterns:
+
+- Generating prompts, checklists, or instructions for the user to paste into PostHog AI, another Claude session, or the customer's own tools. That's not helping; it's silently shifting the work onto the user while hiding *why* this skill couldn't do it.
+- Producing "here's what an audit would look like" template content without real data behind it.
+- Guessing at findings from prior knowledge of the customer or the product.
+
+### When to refuse (each of these triggers the protocol)
+
+| `reason_code` | Condition |
+| --- | --- |
+| `wrong_project` | `what project am I in?` returned a project ID other than the customer's (typically your own, "PostHog App + Website", id 2). Use this whenever the project *identity* is wrong, even if that project happens to be empty. |
+| `empty_project` | The MCP is on the customer's project (identity matches), but `experiment-list` returns zero results. The audit has nothing to work with. Discriminator vs `wrong_project`: identity matches expected. |
+| `mcp_disconnected` | No MCP server is responding at all — tool calls fail before reaching the server (transport error, "MCP not connected", `/mcp` shows no posthog entry). |
+| `mcp_auth_expired` | MCP server responds but returns 401/403 on a call that should succeed (the impersonation session lapsed or the token was revoked mid-audit). |
+| `switch_project_failed` | `switch-project` responded with an error, or the project you tried to switch to isn't in the current user's accessible projects. |
+| `experiment_not_found` | `experiment-list` search returned no match for the experiment the user named. Do not run a similarly-named experiment as a substitute — refuse and ask. |
+| `no_exposure_data` | The experiment exists and the project identity is right, but `$feature_flag_called` returns zero rows since the experiment's start date. The audit has no evidence to work from. |
+| `tool_call_error` | The MCP server responded, auth is valid, but an individual tool call returned an error that blocks a downstream step and can't be worked around. Use this for the "MCP is up but this specific call failed" case. |
+| `other` | Anything the above doesn't cover. Only use when a specific code doesn't fit — always prefer the specific one. |
+
+### What to do on refusal
+
+Output the refusal in chat in this exact shape, and stop:
+
+```
+:no_entry: Cannot complete this audit
+
+What I tried: [one line — e.g. "Confirm scope via 'what project am I in?'"]
+What went wrong: [one line — e.g. "MCP is scoped to 'PostHog App + Website' (id 2), not the customer's project."]
+Why this blocks the audit: [one line — e.g. "Every downstream query would run against your own data, not theirs."]
+How to fix: [concrete next step — e.g. "Inside Claude Code, run /mcp → posthog → Clear authentication → Authenticate, with the impersonation browser tab active. Then re-run this audit."]
+```
+
+Then also append the same refusal as a JSONL entry to `$CSM_IMPERSONATE_REFUSAL_LOG` (env var set by the wrapper — defaults to `~/.local/state/impersonate-audit/refusals.log`). Substitute your own values for every `<...>` placeholder below; do not copy the placeholders verbatim. Use `jq` so free-text fields are safely JSON-escaped:
+
+```bash
+jq -nc \
+  --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --arg session_id "$CSM_IMPERSONATE_SESSION_ID" \
+  --arg account "$CSM_IMPERSONATE_ACCOUNT" \
+  --arg account_name "$CSM_IMPERSONATE_ACCOUNT_NAME" \
+  --arg audit_file "$CSM_IMPERSONATE_AUDIT_FILE" \
+  --arg reason_code "<REASON_CODE>" \
+  --arg tried "<one line of what you tried>" \
+  --arg went_wrong "<one line of what went wrong>" \
+  --arg why_blocks "<one line of why this blocks the audit>" \
+  --arg how_to_fix "<one line of the concrete fix>" \
+  '{ts:$ts, session_id:$session_id, account:$account, account_name:$account_name, audit_file:$audit_file, reason_code:$reason_code, tried:$tried, went_wrong:$went_wrong, why_blocks:$why_blocks, how_to_fix:$how_to_fix}' \
+  >> "$CSM_IMPERSONATE_REFUSAL_LOG"
+```
+
+If `$CSM_IMPERSONATE_REFUSAL_LOG` is unset (skill invoked outside the wrapper), skip the log-write step — do not fall back to a default path. Still emit the refusal in chat and to the audit file.
+
+Then write the same refusal (in the human-readable format above, not JSON) to `$CSM_IMPERSONATE_AUDIT_FILE` — create the file or append. So the audit folder itself carries the record.
+
+The log-write step is not optional when the env var is set. A refusal without a log entry is invisible to future debugging.
+
+### Debug log — capture the raw error for later
+
+Alongside the structured refusal, append every raw MCP error you can see to `$CSM_IMPERSONATE_DEBUG_LOG` (defaults to `~/.local/state/impersonate-audit/debug.log`). This is the log Jake or whoever hits the failure comes back to. The refusal log tells you *that* something failed; the debug log tells you *what the server actually said*.
+
+Write one JSONL entry per raw error observation. The `session_id` field must match the one you wrote to the refusal log so the two are joinable:
+
+```bash
+jq -nc \
+  --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --arg session_id "$CSM_IMPERSONATE_SESSION_ID" \
+  --arg account "$CSM_IMPERSONATE_ACCOUNT" \
+  --arg event "mcp_error" \
+  --arg tool "<tool name — e.g. experiment-list>" \
+  --arg status "<HTTP status or transport class — e.g. 401, timeout, tool_not_found>" \
+  --arg error_class "<short label — e.g. AuthError, ProjectNotFound, RateLimited>" \
+  --arg raw "<verbatim server error string, redacted per the rules below>" \
+  '{ts:$ts, session_id:$session_id, account:$account, event:$event, tool:$tool, status:$status, error_class:$error_class, raw:$raw}' \
+  >> "$CSM_IMPERSONATE_DEBUG_LOG"
+```
+
+Also acceptable events (write one line each as they happen): `probe` (the "what project am I in?" call and its result), `tool_call_success` for calls that completed but returned surprising data (empty list, unexpected id), and `tool_call_error` for individual call failures.
+
+Redaction rules for the `raw` field, applied before you write:
+
+- Replace anything of the shape `Bearer <hex>`, `Bearer <base64>`, `phc_[A-Za-z0-9_-]+`, `phx_[A-Za-z0-9_-]+`, or any 32+ character hex/base64 blob with `<REDACTED-TOKEN>`. When in doubt, redact.
+- Replace any Set-Cookie / session-id header value with `<REDACTED-COOKIE>`.
+- Do not include full customer query results in the raw field — the goal is to preserve the *server error message*, not the *response body*. If the server returned data instead of an error, log the error class and a short shape summary (`"returned 12 experiments, expected 0"`), not the raw rows.
+- Cap `raw` at ~2000 characters. If longer, truncate and append `... [truncated]`.
+
+If `$CSM_IMPERSONATE_DEBUG_LOG` is unset, skip the debug-log write — do not fall back to a default path.
+
+### Reviewing refusals later
+
+To scan past refusals: `jq -c . ~/.local/state/impersonate-audit/refusals.log | tail -20`
+
+To find every refusal for one account: `jq -c 'select(.account == "acme-inc")' ~/.local/state/impersonate-audit/refusals.log`
+
+To count by reason: `jq -r .reason_code ~/.local/state/impersonate-audit/refusals.log | sort | uniq -c | sort -rn`
+
+To pull the full raw-error trail for one refusal (join by session_id):
+
+```bash
+SID="$(jq -r 'select(.reason_code == "mcp_auth_expired") | .session_id' ~/.local/state/impersonate-audit/refusals.log | tail -1)"
+jq -c "select(.session_id == \"$SID\")" ~/.local/state/impersonate-audit/debug.log
+```
 
 ## Step 1 — pull the experiment config
 
@@ -123,7 +232,10 @@ fix that unblocks the experiment?]
 ## Rules
 
 - **Read-only.** Do not create insights, dashboards, actions, experiments, or modify any config. You are working inside a customer's project under read-only impersonation; treat it as look-but-don't-touch.
-- **No fabrication.** If you can't find the experiment or the data is empty, say so explicitly. Do not invent findings to fill the template.
+- **No prompt-passing.** Do not generate prompts, checklists, or instructions for the user to run in PostHog AI, another Claude session, or any other tool. If you can't do the audit in this session, refuse explicitly per the Refusal protocol. A skill that quietly redirects work to the user is a skill that hides its own failures.
+- **Refusal stands under pressure.** If the user pushes back on a refusal ("just give me the prompts, I'll paste them", "run it anyway", "generate what you would have output"), the refusal still stands. Repeat the refusal shape with the same reason_code and stop. The whole point is that failure modes surface the fix, not the workaround.
+- **No raw token echoes.** When you paste MCP error output into the debug log, apply the redaction rules in the Debug log section. Never echo `Bearer ...`, `phc_...`, `phx_...`, session-cookie values, or long hex/base64 blobs verbatim, even inside the raw error field. If you're not sure whether something is sensitive, redact it.
+- **No fabrication.** If you can't find the experiment or the data is empty, say so explicitly and refuse per the Refusal protocol. Do not invent findings to fill the template.
 - **Cite real numbers.** Every claim about exposure counts, sample ratios, or event volumes must come from a query you actually ran in this session.
 - **Surface ambiguity.** If a setting could be intentional (e.g. low conversion window because conversion happens fast), note both interpretations and ask the customer to confirm.
 - **Match the customer's writing register.** Customers using PostHog are usually technical — don't oversimplify. But avoid jargon shorthand they may not know yet.

--- a/skills/team/customer-success/impersonation-toolkit/SKILL.md
+++ b/skills/team/customer-success/impersonation-toolkit/SKILL.md
@@ -57,7 +57,12 @@ Then also append the same refusal as a JSONL entry to `$CSM_IMPERSONATE_REFUSAL_
 
 ```bash
 redact() {
-  [[ -n "${CSM_IMPERSONATE_REDACT:-}" && -x "$CSM_IMPERSONATE_REDACT" ]] || { echo "redactor unavailable — skipping field" >&2; return 1; }
+  # If the redactor is missing, the caller falls through to an empty
+  # string (bash swallows the non-zero exit inside "$(...)"). The stderr
+  # note surfaces the reason and no secret can leak — safer than a raw
+  # write. Prefer running under the wrapper where the env var is always
+  # set to a real script.
+  [[ -n "${CSM_IMPERSONATE_REDACT:-}" && -x "$CSM_IMPERSONATE_REDACT" ]] || { echo "redactor unavailable — field will be empty" >&2; return 1; }
   printf '%s' "$1" | "$CSM_IMPERSONATE_REDACT"
 }
 
@@ -106,7 +111,12 @@ Write one JSONL entry per raw error observation. The `session_id` field must mat
 
 ```bash
 redact() {
-  [[ -n "${CSM_IMPERSONATE_REDACT:-}" && -x "$CSM_IMPERSONATE_REDACT" ]] || { echo "redactor unavailable — skipping field" >&2; return 1; }
+  # If the redactor is missing, the caller falls through to an empty
+  # string (bash swallows the non-zero exit inside "$(...)"). The stderr
+  # note surfaces the reason and no secret can leak — safer than a raw
+  # write. Prefer running under the wrapper where the env var is always
+  # set to a real script.
+  [[ -n "${CSM_IMPERSONATE_REDACT:-}" && -x "$CSM_IMPERSONATE_REDACT" ]] || { echo "redactor unavailable — field will be empty" >&2; return 1; }
   printf '%s' "$1" | "$CSM_IMPERSONATE_REDACT"
 }
 

--- a/skills/team/customer-success/impersonation-toolkit/SKILL.md
+++ b/skills/team/customer-success/impersonation-toolkit/SKILL.md
@@ -56,7 +56,10 @@ How to fix: [concrete next step — e.g. "Inside Claude Code, run /mcp → posth
 Then also append the same refusal as a JSONL entry to `$CSM_IMPERSONATE_REFUSAL_LOG` (env var set by the wrapper — defaults to `~/.local/state/impersonate-audit/refusals.log`). Substitute your own values for every `<...>` placeholder below; do not copy the placeholders verbatim. Every free-text field is piped through the deterministic redactor at `$CSM_IMPERSONATE_REDACT` before it reaches `jq`, so token-shaped strings can't survive to disk even if you mis-classify them:
 
 ```bash
-redact() { printf '%s' "$1" | "$CSM_IMPERSONATE_REDACT"; }
+redact() {
+  [[ -n "${CSM_IMPERSONATE_REDACT:-}" && -x "$CSM_IMPERSONATE_REDACT" ]] || { echo "redactor unavailable — skipping field" >&2; return 1; }
+  printf '%s' "$1" | "$CSM_IMPERSONATE_REDACT"
+}
 
 jq -nc \
   --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
@@ -77,7 +80,21 @@ Every free-text field in the refusal — `tried`, `went_wrong`, `why_blocks`, `h
 
 If `$CSM_IMPERSONATE_REFUSAL_LOG` is unset (skill invoked outside the wrapper), skip the log-write step — do not fall back to a default path. Still emit the refusal in chat and to the audit file.
 
-Then write the same refusal (in the human-readable format above, not JSON) to `$CSM_IMPERSONATE_AUDIT_FILE` — create the file or append. Include a `Session: <id>` footer line so the audit file joins back to the debug log without needing the terminal banner.
+Then write the same refusal (in the human-readable format above, not JSON) to `$CSM_IMPERSONATE_AUDIT_FILE` — create the file or append. **Build each of the four content lines through `redact()` before writing, exactly like the JSONL block.** The audit file is a durable, human-readable artifact — often committed to a notes repo or shared with the customer — and must not carry token material that the JSONL sibling was careful to strip. Include a `Session: <id>` footer line so the audit file joins back to the debug log without needing the terminal banner.
+
+```bash
+cat >> "$CSM_IMPERSONATE_AUDIT_FILE" <<EOF
+
+:no_entry: Cannot complete this audit
+
+What I tried: $(redact "<one line of what you tried>")
+What went wrong: $(redact "<one line of what went wrong>")
+Why this blocks the audit: $(redact "<one line of why this blocks the audit>")
+How to fix: $(redact "<one line of the concrete fix>")
+
+Session: $CSM_IMPERSONATE_SESSION_ID
+EOF
+```
 
 The log-write step is not optional when the env var is set. A refusal without a log entry is invisible to future debugging.
 
@@ -88,15 +105,18 @@ Alongside the structured refusal, append every raw MCP error you can see to `$CS
 Write one JSONL entry per raw error observation. The `session_id` field must match the one you wrote to the refusal log so the two are joinable. Every free-text field goes through the redactor before it reaches `jq`:
 
 ```bash
-redact() { printf '%s' "$1" | "$CSM_IMPERSONATE_REDACT"; }
+redact() {
+  [[ -n "${CSM_IMPERSONATE_REDACT:-}" && -x "$CSM_IMPERSONATE_REDACT" ]] || { echo "redactor unavailable — skipping field" >&2; return 1; }
+  printf '%s' "$1" | "$CSM_IMPERSONATE_REDACT"
+}
 
 jq -nc \
   --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
   --arg session_id "$CSM_IMPERSONATE_SESSION_ID" \
   --arg account "$CSM_IMPERSONATE_ACCOUNT" \
-  --arg event "<event type — e.g. mcp_error, probe, tool_call_error>" \
-  --arg tool "<tool name — e.g. experiment-list>" \
-  --arg status "<HTTP status or transport class — e.g. 401, timeout, tool_not_found>" \
+  --arg event "$(redact "<event type — e.g. mcp_error, probe, tool_call_error>")" \
+  --arg tool "$(redact "<tool name — e.g. experiment-list>")" \
+  --arg status "$(redact "<HTTP status or transport class — e.g. 401, timeout, tool_not_found>")" \
   --arg error_class "$(redact "<short label — e.g. AuthError, ProjectNotFound>")" \
   --arg raw "$(redact "<verbatim server error string, capped at ~2000 chars>")" \
   '{ts:$ts, session_id:$session_id, account:$account, event:$event, tool:$tool, status:$status, error_class:$error_class, raw:$raw}' \
@@ -111,7 +131,9 @@ Redaction is done by piping through `$CSM_IMPERSONATE_REDACT` — a deterministi
 - `phc_...`, `phx_...`, `phs_...`, `sTOK_...` and any known PostHog token prefix — keeps the prefix so you know the *shape* of what leaked, redacts the secret tail.
 - JWTs (`eyJ<header>.<payload>.<signature>`) — one-shot redacted to `<REDACTED-JWT>`.
 - Cookie / Set-Cookie header values.
-- Any 24+ character run from the base64url alphabet — catch-all for OAuth codes, session IDs, unrecognized token shapes.
+- Framed secrets — a keyword like `token`, `code`, `access_token`, `refresh_token`, `authorization`, `secret`, `api_key` followed by `:` / `=` / whitespace and a token-shaped value. The rule anchors on the keyword so it names what it protects and leaves free-standing identifiers (flag keys, class names, slugs) alone.
+
+Note: there is deliberately no pure length+charset catch-all. That pattern ate legitimate identifiers and the debug log's value depends on preserving them so a human can grep. When a new token shape shows up in the wild, add a named rule for it.
 
 Additional rules for the `raw` field content itself:
 

--- a/skills/team/customer-success/impersonation-toolkit/SKILL.md
+++ b/skills/team/customer-success/impersonation-toolkit/SKILL.md
@@ -37,8 +37,7 @@ If any structural condition prevents you from actually auditing the customer's p
 | `mcp_auth_expired` | MCP server responds but returns 401/403 on a call that should succeed (the impersonation session lapsed or the token was revoked mid-audit). |
 | `switch_project_failed` | `switch-project` responded with an error, or the project you tried to switch to isn't in the current user's accessible projects. |
 | `experiment_not_found` | `experiment-list` search returned no match for the experiment the user named. Do not run a similarly-named experiment as a substitute — refuse and ask. |
-| `no_exposure_data` | The experiment exists and the project identity is right, but `$feature_flag_called` returns zero rows since the experiment's start date. The audit has no evidence to work from. |
-| `tool_call_error` | The MCP server responded, auth is valid, but an individual tool call returned an error that blocks a downstream step and can't be worked around. Use this for the "MCP is up but this specific call failed" case. |
+| `tool_call_error` | The MCP server responded, auth is valid, but an individual tool call returned an error that blocks a downstream step and can't be worked around. Use this for the "MCP is up but this specific call failed" case. If the *exposure query itself* errored (500, timeout, malformed response), this is the code — but a query that succeeds and returns zero rows is an audit finding, not a refusal (see Step 3). |
 | `other` | Anything the above doesn't cover. Only use when a specific code doesn't fit — always prefer the specific one. |
 
 ### What to do on refusal
@@ -54,9 +53,11 @@ Why this blocks the audit: [one line — e.g. "Every downstream query would run 
 How to fix: [concrete next step — e.g. "Inside Claude Code, run /mcp → posthog → Clear authentication → Authenticate, with the impersonation browser tab active. Then re-run this audit."]
 ```
 
-Then also append the same refusal as a JSONL entry to `$CSM_IMPERSONATE_REFUSAL_LOG` (env var set by the wrapper — defaults to `~/.local/state/impersonate-audit/refusals.log`). Substitute your own values for every `<...>` placeholder below; do not copy the placeholders verbatim. Use `jq` so free-text fields are safely JSON-escaped:
+Then also append the same refusal as a JSONL entry to `$CSM_IMPERSONATE_REFUSAL_LOG` (env var set by the wrapper — defaults to `~/.local/state/impersonate-audit/refusals.log`). Substitute your own values for every `<...>` placeholder below; do not copy the placeholders verbatim. Every free-text field is piped through the deterministic redactor at `$CSM_IMPERSONATE_REDACT` before it reaches `jq`, so token-shaped strings can't survive to disk even if you mis-classify them:
 
 ```bash
+redact() { printf '%s' "$1" | "$CSM_IMPERSONATE_REDACT"; }
+
 jq -nc \
   --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
   --arg session_id "$CSM_IMPERSONATE_SESSION_ID" \
@@ -64,17 +65,19 @@ jq -nc \
   --arg account_name "$CSM_IMPERSONATE_ACCOUNT_NAME" \
   --arg audit_file "$CSM_IMPERSONATE_AUDIT_FILE" \
   --arg reason_code "<REASON_CODE>" \
-  --arg tried "<one line of what you tried>" \
-  --arg went_wrong "<one line of what went wrong>" \
-  --arg why_blocks "<one line of why this blocks the audit>" \
-  --arg how_to_fix "<one line of the concrete fix>" \
+  --arg tried "$(redact "<one line of what you tried>")" \
+  --arg went_wrong "$(redact "<one line of what went wrong>")" \
+  --arg why_blocks "$(redact "<one line of why this blocks the audit>")" \
+  --arg how_to_fix "$(redact "<one line of the concrete fix>")" \
   '{ts:$ts, session_id:$session_id, account:$account, account_name:$account_name, audit_file:$audit_file, reason_code:$reason_code, tried:$tried, went_wrong:$went_wrong, why_blocks:$why_blocks, how_to_fix:$how_to_fix}' \
   >> "$CSM_IMPERSONATE_REFUSAL_LOG"
 ```
 
+Every free-text field in the refusal — `tried`, `went_wrong`, `why_blocks`, `how_to_fix` — must go through the redactor. `account_name` doesn't (it's the customer name you already have in the wrapper env).
+
 If `$CSM_IMPERSONATE_REFUSAL_LOG` is unset (skill invoked outside the wrapper), skip the log-write step — do not fall back to a default path. Still emit the refusal in chat and to the audit file.
 
-Then write the same refusal (in the human-readable format above, not JSON) to `$CSM_IMPERSONATE_AUDIT_FILE` — create the file or append. So the audit folder itself carries the record.
+Then write the same refusal (in the human-readable format above, not JSON) to `$CSM_IMPERSONATE_AUDIT_FILE` — create the file or append. Include a `Session: <id>` footer line so the audit file joins back to the debug log without needing the terminal banner.
 
 The log-write step is not optional when the env var is set. A refusal without a log entry is invisible to future debugging.
 
@@ -82,29 +85,37 @@ The log-write step is not optional when the env var is set. A refusal without a 
 
 Alongside the structured refusal, append every raw MCP error you can see to `$CSM_IMPERSONATE_DEBUG_LOG` (defaults to `~/.local/state/impersonate-audit/debug.log`). This is the log Jake or whoever hits the failure comes back to. The refusal log tells you *that* something failed; the debug log tells you *what the server actually said*.
 
-Write one JSONL entry per raw error observation. The `session_id` field must match the one you wrote to the refusal log so the two are joinable:
+Write one JSONL entry per raw error observation. The `session_id` field must match the one you wrote to the refusal log so the two are joinable. Every free-text field goes through the redactor before it reaches `jq`:
 
 ```bash
+redact() { printf '%s' "$1" | "$CSM_IMPERSONATE_REDACT"; }
+
 jq -nc \
   --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
   --arg session_id "$CSM_IMPERSONATE_SESSION_ID" \
   --arg account "$CSM_IMPERSONATE_ACCOUNT" \
-  --arg event "mcp_error" \
+  --arg event "<event type — e.g. mcp_error, probe, tool_call_error>" \
   --arg tool "<tool name — e.g. experiment-list>" \
   --arg status "<HTTP status or transport class — e.g. 401, timeout, tool_not_found>" \
-  --arg error_class "<short label — e.g. AuthError, ProjectNotFound, RateLimited>" \
-  --arg raw "<verbatim server error string, redacted per the rules below>" \
+  --arg error_class "$(redact "<short label — e.g. AuthError, ProjectNotFound>")" \
+  --arg raw "$(redact "<verbatim server error string, capped at ~2000 chars>")" \
   '{ts:$ts, session_id:$session_id, account:$account, event:$event, tool:$tool, status:$status, error_class:$error_class, raw:$raw}' \
   >> "$CSM_IMPERSONATE_DEBUG_LOG"
 ```
 
-Also acceptable events (write one line each as they happen): `probe` (the "what project am I in?" call and its result), `tool_call_success` for calls that completed but returned surprising data (empty list, unexpected id), and `tool_call_error` for individual call failures.
+Acceptable event values (write one JSONL line per event as it happens): `probe` (the "what project am I in?" call and its result — but log only the project ID, not the full response body), `tool_call_success` for calls that completed but returned surprising data (empty list, unexpected id), `tool_call_error` for individual call failures, `mcp_error` for transport / auth-level failures.
 
-Redaction rules for the `raw` field, applied before you write:
+Redaction is done by piping through `$CSM_IMPERSONATE_REDACT` — a deterministic Perl script that runs outside the LLM, so no prompt-injected error body can talk you into skipping it. What it catches:
 
-- Replace anything of the shape `Bearer <hex>`, `Bearer <base64>`, `phc_[A-Za-z0-9_-]+`, `phx_[A-Za-z0-9_-]+`, or any 32+ character hex/base64 blob with `<REDACTED-TOKEN>`. When in doubt, redact.
-- Replace any Set-Cookie / session-id header value with `<REDACTED-COOKIE>`.
-- Do not include full customer query results in the raw field — the goal is to preserve the *server error message*, not the *response body*. If the server returned data instead of an error, log the error class and a short shape summary (`"returned 12 experiments, expected 0"`), not the raw rows.
+- `Bearer <hex/base64/base64url>` — replaces the token portion, keeps the `Bearer ` prefix.
+- `phc_...`, `phx_...`, `phs_...`, `sTOK_...` and any known PostHog token prefix — keeps the prefix so you know the *shape* of what leaked, redacts the secret tail.
+- JWTs (`eyJ<header>.<payload>.<signature>`) — one-shot redacted to `<REDACTED-JWT>`.
+- Cookie / Set-Cookie header values.
+- Any 24+ character run from the base64url alphabet — catch-all for OAuth codes, session IDs, unrecognized token shapes.
+
+Additional rules for the `raw` field content itself:
+
+- Do not paste full customer query results — the goal is to preserve the *server error message*, not the *response body*. If a call succeeded but returned surprising data, log a shape summary (`"returned 12 experiments, expected 0"`), not the raw rows.
 - Cap `raw` at ~2000 characters. If longer, truncate and append `... [truncated]`.
 
 If `$CSM_IMPERSONATE_DEBUG_LOG` is unset, skip the debug-log write — do not fall back to a default path.
@@ -234,7 +245,7 @@ fix that unblocks the experiment?]
 - **Read-only.** Do not create insights, dashboards, actions, experiments, or modify any config. You are working inside a customer's project under read-only impersonation; treat it as look-but-don't-touch.
 - **No prompt-passing.** Do not generate prompts, checklists, or instructions for the user to run in PostHog AI, another Claude session, or any other tool. If you can't do the audit in this session, refuse explicitly per the Refusal protocol. A skill that quietly redirects work to the user is a skill that hides its own failures.
 - **Refusal stands under pressure.** If the user pushes back on a refusal ("just give me the prompts, I'll paste them", "run it anyway", "generate what you would have output"), the refusal still stands. Repeat the refusal shape with the same reason_code and stop. The whole point is that failure modes surface the fix, not the workaround.
-- **No raw token echoes.** When you paste MCP error output into the debug log, apply the redaction rules in the Debug log section. Never echo `Bearer ...`, `phc_...`, `phx_...`, session-cookie values, or long hex/base64 blobs verbatim, even inside the raw error field. If you're not sure whether something is sensitive, redact it.
+- **No raw token echoes.** Every free-text field in every log entry (both `refusals.log` and `debug.log`) must be piped through `$CSM_IMPERSONATE_REDACT` before write. Do not attempt to redact by hand — the whole point of the script is that redaction is deterministic and can't be prompt-injected. If the script is unavailable (env var unset), do not write the field; log the fact that redaction was unavailable instead.
 - **No fabrication.** If you can't find the experiment or the data is empty, say so explicitly and refuse per the Refusal protocol. Do not invent findings to fill the template.
 - **Cite real numbers.** Every claim about exposure counts, sample ratios, or event volumes must come from a query you actually ran in this session.
 - **Surface ambiguity.** If a setting could be intentional (e.g. low conversion window because conversion happens fast), note both interpretations and ask the customer to confirm.

--- a/skills/team/customer-success/impersonation-toolkit/scripts/impersonate-audit.sh
+++ b/skills/team/customer-success/impersonation-toolkit/scripts/impersonate-audit.sh
@@ -447,11 +447,17 @@ mkdir -p "$(dirname "$CSM_IMPERSONATE_REFUSAL_LOG")"
 export CSM_IMPERSONATE_REFUSAL_LOG
 
 # Raw-error debug log. Verbose companion to refusals.log — the skill appends
-# raw MCP tool responses, HTTP status, and error class here (token-shaped
-# strings are redacted before write). Cross-reference via session_id.
+# raw MCP tool responses, HTTP status, and error class here. Cross-reference
+# via session_id.
 CSM_IMPERSONATE_DEBUG_LOG="${CSM_IMPERSONATE_DEBUG_LOG:-${XDG_STATE_HOME:-$HOME/.local/state}/impersonate-audit/debug.log}"
 mkdir -p "$(dirname "$CSM_IMPERSONATE_DEBUG_LOG")"
 export CSM_IMPERSONATE_DEBUG_LOG
+
+# Deterministic redactor. Free-text fields written to either log are piped
+# through this before write, so token-shaped strings can't survive to disk
+# even if the skill mis-classifies them. Ships with the plugin.
+CSM_IMPERSONATE_REDACT="${CSM_IMPERSONATE_REDACT:-$SCRIPT_DIR/redact.sh}"
+export CSM_IMPERSONATE_REDACT
 
 cd "$CSM_IMPERSONATE_HOME"
 
@@ -466,6 +472,7 @@ cat <<EOF
   Session:     $CSM_IMPERSONATE_SESSION_ID
   Refusals:    $CSM_IMPERSONATE_REFUSAL_LOG
   Debug log:   $CSM_IMPERSONATE_DEBUG_LOG
+  Redactor:    $CSM_IMPERSONATE_REDACT
 EOF
 
 if [[ -n "$CSM_CUSTOMER_CONTEXT_DIR" ]]; then

--- a/skills/team/customer-success/impersonation-toolkit/scripts/impersonate-audit.sh
+++ b/skills/team/customer-success/impersonation-toolkit/scripts/impersonate-audit.sh
@@ -431,6 +431,28 @@ export CSM_IMPERSONATE_ACCOUNT_DIR="$ACCOUNT_DIR"
 export CSM_IMPERSONATE_AUDIT_FILE="$AUDIT_FILE"
 export CSM_CUSTOMER_CONTEXT_DIR
 
+# Session ID lets you correlate refusal-log entries with the raw-error debug
+# log — `jq 'select(.session_id == "...")'` across both files.
+if command -v uuidgen >/dev/null 2>&1; then
+  CSM_IMPERSONATE_SESSION_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+else
+  CSM_IMPERSONATE_SESSION_ID="$(od -An -N16 -tx1 /dev/urandom | tr -d ' \n')"
+fi
+export CSM_IMPERSONATE_SESSION_ID
+
+# Cross-session refusal log. The skill appends one JSONL entry when it can't
+# complete an audit — grep / jq across it to see what's failing over time.
+CSM_IMPERSONATE_REFUSAL_LOG="${CSM_IMPERSONATE_REFUSAL_LOG:-${XDG_STATE_HOME:-$HOME/.local/state}/impersonate-audit/refusals.log}"
+mkdir -p "$(dirname "$CSM_IMPERSONATE_REFUSAL_LOG")"
+export CSM_IMPERSONATE_REFUSAL_LOG
+
+# Raw-error debug log. Verbose companion to refusals.log — the skill appends
+# raw MCP tool responses, HTTP status, and error class here (token-shaped
+# strings are redacted before write). Cross-reference via session_id.
+CSM_IMPERSONATE_DEBUG_LOG="${CSM_IMPERSONATE_DEBUG_LOG:-${XDG_STATE_HOME:-$HOME/.local/state}/impersonate-audit/debug.log}"
+mkdir -p "$(dirname "$CSM_IMPERSONATE_DEBUG_LOG")"
+export CSM_IMPERSONATE_DEBUG_LOG
+
 cd "$CSM_IMPERSONATE_HOME"
 
 cat <<EOF
@@ -441,6 +463,9 @@ cat <<EOF
   Folder:      $ACCOUNT_SLUG/  (notes, exports, scratch files)
   Audit:       $ACCOUNT_SLUG/$(basename "$AUDIT_FILE")
   Perms:       $SETTINGS_FILE
+  Session:     $CSM_IMPERSONATE_SESSION_ID
+  Refusals:    $CSM_IMPERSONATE_REFUSAL_LOG
+  Debug log:   $CSM_IMPERSONATE_DEBUG_LOG
 EOF
 
 if [[ -n "$CSM_CUSTOMER_CONTEXT_DIR" ]]; then

--- a/skills/team/customer-success/impersonation-toolkit/scripts/redact-test.sh
+++ b/skills/team/customer-success/impersonation-toolkit/scripts/redact-test.sh
@@ -61,6 +61,16 @@ run "plain English stays"             'the impersonation session lapsed and swit
 run "regular filename stays"          'writing to refusals-log-file.json'                       'writing to refusals-log-file.json'
 run "empty input"                     ''                                                        ''
 
+# --- compound-key false positives (the keyword must be a word start) ---
+run "compound error_code stays"       'error_code: resource_not_found_here'                     'error_code: resource_not_found_here'
+run "compound reason_code stays"      'reason_code=INVALID_TOKEN_HERE'                          'reason_code=INVALID_TOKEN_HERE'
+run "compound status_code stays"      'status_code=tool_not_found_ever'                         'status_code=tool_not_found_ever'
+run "json code with diagnostic stays" '{"error":{"code":"resource_not_found"}}'                 '{"error":{"code":"resource_not_found"}}'
+run "code= diagnostic string stays"   'code: PROJECT_NOT_FOUND'                                 'code: PROJECT_NOT_FOUND'
+
+# --- but a compound key with a digit-bearing token value STILL redacts if the keyword itself is real ---
+run "token= real value still redacts" 'token=abc123def456ghi789'                                'token=<REDACTED-TOKEN>'
+
 echo
 echo "  ${pass} passed, ${fail} failed"
 

--- a/skills/team/customer-success/impersonation-toolkit/scripts/redact-test.sh
+++ b/skills/team/customer-success/impersonation-toolkit/scripts/redact-test.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# Regression tests for redact.sh. Run manually: `bash scripts/redact-test.sh`.
+# When a new token shape lands in the wild and gets a new named rule in
+# redact.sh, add a case here so the pattern is regression-tested.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REDACT="$SCRIPT_DIR/redact.sh"
+
+pass=0
+fail=0
+
+run() {
+  local name="$1" input="$2" expected="$3" got
+  got="$(printf '%s' "$input" | "$REDACT")"
+  if [[ "$got" == "$expected" ]]; then
+    pass=$((pass+1))
+    printf '  PASS  %s\n' "$name"
+  else
+    fail=$((fail+1))
+    printf '  FAIL  %s\n' "$name"
+    printf '        input:    %s\n' "$input"
+    printf '        expected: %s\n' "$expected"
+    printf '        got:      %s\n' "$got"
+  fi
+}
+
+# --- named prefix rules ---
+run "Bearer hex tail"                 'Authorization: Bearer abcdef1234567890abcdef1234567890'  'Authorization: Bearer <REDACTED-TOKEN>'
+run "Bearer base64url tail"           'Bearer aGVsbG8td29ybGRfdGVzdC1zdHJpbmc'                  'Bearer <REDACTED-TOKEN>'
+run "phc_ prefix"                     'phc_ABCDEFGH1234'                                        'phc_<REDACTED-TOKEN>'
+run "phx_ prefix"                     'phx_XYZ9876543'                                          'phx_<REDACTED-TOKEN>'
+run "phs_ prefix"                     'invalid phs_secret_key_here_abc'                         'invalid phs_<REDACTED-TOKEN>'
+run "sTOK_ prefix"                    'sTOK_abcdef123'                                          'sTOK_<REDACTED-TOKEN>'
+
+# --- JWT ---
+run "JWT base64url"                   'token: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.SflKxwRJSMeKKF2QT4fw'                   'token: <REDACTED-JWT>'
+run "JWT with + and / in payload"     'token: eyJhbGciOi.eyJz+wI/12MifQ.SflKxwRJSMeKKF2QT4fw'                                  'token: <REDACTED-JWT>'
+
+# --- cookies ---
+run "cookie header uppercase"         'Set-Cookie: sessionid=xyz_val; Path=/'                   'Set-Cookie: <REDACTED-COOKIE>'
+run "cookie header lowercase"         'cookie: sessionid=xyz_val'                               'cookie: <REDACTED-COOKIE>'
+
+# --- framed secrets (the replacement for the old catch-all) ---
+run "framed authorization + token= "  'authorization: eyJhbGciOi.eyJzdWIi.SflKxwRJ and token=abc123def456ghi789' 'authorization: <REDACTED-JWT> and token=<REDACTED-TOKEN>'
+run "framed access_token JSON"        '{"access_token":"abcdef1234567890abcdef1234567890"}'     '{"access_token":"<REDACTED-TOKEN>"}'
+run "framed code= param"              'callback?code=4/0AVMBsJgH-bYd8U9K3fRvHZ2wQ'               'callback?code=<REDACTED-TOKEN>'
+run "framed secret with space sep"    'secret abcdef1234567890'                                 'secret <REDACTED-TOKEN>'
+
+# --- multiple tokens on one line ---
+run "multiple tokens same line"       'Bearer abcdef1234567890abcdef1234567890 and phs_secret_key_xyz123' 'Bearer <REDACTED-TOKEN> and phs_<REDACTED-TOKEN>'
+
+# --- must NOT be redacted (the whole reason we dropped the catch-all) ---
+run "long flag key stays"             'flag: checkout-conversion-experiment-v2 rejected'        'flag: checkout-conversion-experiment-v2 rejected'
+run "PascalCase exception stays"      'Raised ProjectMembershipValidationFailed at boundary'    'Raised ProjectMembershipValidationFailed at boundary'
+run "long slug stays"                 'account: really-long-customer-account-slug'              'account: really-long-customer-account-slug'
+run "URL path stays"                  'GET /api/experiments?limit=10'                           'GET /api/experiments?limit=10'
+run "plain English stays"             'the impersonation session lapsed and switch-project returned 403' 'the impersonation session lapsed and switch-project returned 403'
+run "regular filename stays"          'writing to refusals-log-file.json'                       'writing to refusals-log-file.json'
+run "empty input"                     ''                                                        ''
+
+echo
+echo "  ${pass} passed, ${fail} failed"
+
+if (( fail > 0 )); then
+  exit 1
+fi

--- a/skills/team/customer-success/impersonation-toolkit/scripts/redact.sh
+++ b/skills/team/customer-success/impersonation-toolkit/scripts/redact.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Deterministic redactor for the impersonate-audit debug + refusal logs.
+# Reads stdin, writes redacted output to stdout. Never modifies files itself —
+# the caller pipes into it and writes the result wherever they need to.
+#
+# Redaction is done outside the LLM so it can't be prompt-injected into
+# skipping a rule. Patterns are conservative — a false positive (over-redact)
+# is safer than a false negative (leak).
+
+set -euo pipefail
+
+# perl is the portable choice for PCRE-like alternation and lookbehind.
+# It ships on macOS by default and every Linux distro we care about.
+exec perl -pe '
+  # JWT: three base64url segments separated by dots, header starts with eyJ.
+  s{\beyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\b}{<REDACTED-JWT>}g;
+
+  # Bearer tokens — hex, base64, or base64url tail.
+  s{\bBearer\s+[A-Za-z0-9+/=_.\-]{8,}}{Bearer <REDACTED-TOKEN>}gi;
+
+  # PostHog token prefixes we know about. No length floor — the prefix alone
+  # is enough signal that whatever follows is secret material.
+  s{\b(phc_|phx_|phs_|sTOK_)[A-Za-z0-9_\-]+}{$1<REDACTED-TOKEN>}g;
+
+  # Cookie / Set-Cookie header values.
+  s{(?i)(cookie:\s*)([^\r\n]+)}{$1<REDACTED-COOKIE>}g;
+  s{(?i)(set-cookie:\s*)([^\r\n]+)}{$1<REDACTED-COOKIE>}g;
+
+  # Catch-all for token-shaped blobs (24+ chars from the base64url + padding
+  # alphabet). Lower than 32 so short OAuth codes are still caught. Anchored
+  # on word boundaries so it does not eat ordinary long identifiers embedded
+  # in words. Applies after the specific rules above so those wins.
+  s{\b[A-Za-z0-9+/=_-]{24,}\b}{<REDACTED-TOKEN>}g;
+'

--- a/skills/team/customer-success/impersonation-toolkit/scripts/redact.sh
+++ b/skills/team/customer-success/impersonation-toolkit/scripts/redact.sh
@@ -12,24 +12,39 @@ set -euo pipefail
 
 # perl is the portable choice for PCRE-like alternation and lookbehind.
 # It ships on macOS by default and every Linux distro we care about.
+#
+# Each rule names the shape it is redacting. There is deliberately no
+# "long-string-in-alphabet" catch-all — that pattern ate legitimate identifiers
+# (long flag keys, PascalCase exception classes, kebab-case slugs) and the
+# debug log's whole value is preserving those exact strings so a human can
+# grep them. When a new token shape shows up in the wild, add a named rule.
 exec perl -pe '
-  # JWT: three base64url segments separated by dots, header starts with eyJ.
-  s{\beyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\b}{<REDACTED-JWT>}g;
+  # JWT: three base64-or-base64url segments separated by dots, header starts
+  # with eyJ. Standard base64 (`+`, `/`) is included so we handle non-strict
+  # encoders as well as RFC 7515 base64url.
+  s{\beyJ[A-Za-z0-9+/=_-]{5,}\.[A-Za-z0-9+/=_-]{5,}\.[A-Za-z0-9+/=_-]{5,}\b}{<REDACTED-JWT>}g;
 
   # Bearer tokens — hex, base64, or base64url tail.
   s{\bBearer\s+[A-Za-z0-9+/=_.\-]{8,}}{Bearer <REDACTED-TOKEN>}gi;
 
-  # PostHog token prefixes we know about. No length floor — the prefix alone
-  # is enough signal that whatever follows is secret material.
+  # PostHog token prefixes. No length floor — the prefix alone is enough
+  # signal that whatever follows is secret material.
   s{\b(phc_|phx_|phs_|sTOK_)[A-Za-z0-9_\-]+}{$1<REDACTED-TOKEN>}g;
 
   # Cookie / Set-Cookie header values.
   s{(?i)(cookie:\s*)([^\r\n]+)}{$1<REDACTED-COOKIE>}g;
   s{(?i)(set-cookie:\s*)([^\r\n]+)}{$1<REDACTED-COOKIE>}g;
 
-  # Catch-all for token-shaped blobs (24+ chars from the base64url + padding
-  # alphabet). Lower than 32 so short OAuth codes are still caught. Anchored
-  # on word boundaries so it does not eat ordinary long identifiers embedded
-  # in words. Applies after the specific rules above so those wins.
-  s{\b[A-Za-z0-9+/=_-]{24,}\b}{<REDACTED-TOKEN>}g;
+  # Framed secret rule — a keyword like "token", "code", "authorization"
+  # followed by a token-shaped value. Anchored on the keyword so it names
+  # what it is protecting; leaves free-standing identifiers alone.
+  # Handles JSON (`"access_token":"..."`), query-string (`code=...`), and
+  # plain (`token abc123`) framings.
+  s{
+    ((?i:access_token|refresh_token|authorization|api_key|secret|token|code))  # keyword
+    (["\x27]?)                                                                  # optional closing quote after keyword (JSON)
+    (\s*[:=]\s*|\s+)                                                            # separator (colon, equals, or whitespace)
+    (["\x27]?)                                                                  # optional opening quote before value
+    ([A-Za-z0-9+/=_.\-]{8,})                                                    # token-shaped value
+  }{$1$2$3$4<REDACTED-TOKEN>}gx;
 '

--- a/skills/team/customer-success/impersonation-toolkit/scripts/redact.sh
+++ b/skills/team/customer-success/impersonation-toolkit/scripts/redact.sh
@@ -36,15 +36,21 @@ exec perl -pe '
   s{(?i)(set-cookie:\s*)([^\r\n]+)}{$1<REDACTED-COOKIE>}g;
 
   # Framed secret rule — a keyword like "token", "code", "authorization"
-  # followed by a token-shaped value. Anchored on the keyword so it names
-  # what it is protecting; leaves free-standing identifiers alone.
+  # followed by a token-shaped value. Two guards keep false positives out:
+  #   1. Left lookbehind rejects compound keys like "error_code",
+  #      "reason_code", "status_code" — the keyword must be a word start.
+  #   2. Value must contain at least one digit. Diagnostic snake_case
+  #      constants ("resource_not_found", "INVALID_TOKEN") get through
+  #      untouched because they have no digits; real tokens almost always
+  #      contain some digit or a base64-family symbol.
   # Handles JSON (`"access_token":"..."`), query-string (`code=...`), and
   # plain (`token abc123`) framings.
   s{
-    ((?i:access_token|refresh_token|authorization|api_key|secret|token|code))  # keyword
-    (["\x27]?)                                                                  # optional closing quote after keyword (JSON)
-    (\s*[:=]\s*|\s+)                                                            # separator (colon, equals, or whitespace)
-    (["\x27]?)                                                                  # optional opening quote before value
-    ([A-Za-z0-9+/=_.\-]{8,})                                                    # token-shaped value
+    (?<![A-Za-z0-9_])                                                           # word-start before keyword
+    ((?i:access_token|refresh_token|authorization|api_key|secret|token|code))   # keyword
+    (["\x27]?)                                                                  # optional closing quote (JSON)
+    (\s*[:=]\s*|\s+)                                                            # separator
+    (["\x27]?)                                                                  # optional opening quote
+    ((?=[A-Za-z0-9+/=_.\-]*[0-9])[A-Za-z0-9+/=_.\-]{8,})                        # token-shaped value w/ ≥1 digit
   }{$1$2$3$4<REDACTED-TOKEN>}gx;
 '


### PR DESCRIPTION
## Summary

Jake reported having to uninstall the impersonation-toolkit plugin because when it detected it was on the wrong project, it stopped running the audit but *silently fell back* to handing him prompts to paste into PostHog AI in the customer's project. The skill was doing the wrong helpful thing.

This change makes the failure mode surface the fix instead of shifting work onto the user, and captures enough context to debug the failure later.

## Behavior

- **Step 0** now enumerates three outcomes (customer's project → proceed; own project → refuse; MCP fails → refuse) instead of the ambiguous "STOP".
- **New "Refusal protocol" section** with a 9-row `reason_code` table, exact refusal template, `jq` spec for the log writes, and README-side review queries. Discriminators spelled out for the pairs that could otherwise overlap (`wrong_project` vs `empty_project`; `mcp_disconnected` vs `tool_call_error`).
- **New rules**:
  - **No prompt-passing** — Jake's exact anti-pattern, named by name. If the skill can't do the audit here, it refuses rather than redirecting the work.
  - **Refusal stands under pressure** — don't cave when the user asks for prompts anyway.
  - **No raw token echoes** — redact `Bearer`, `phc_`, `phx_`, and long hex/base64 blobs before writing to debug.log.

## Logging

Two files under `${XDG_STATE_HOME:-~/.local/state}/impersonate-audit/`:

- **`refusals.log`** — one JSONL entry per refused audit. Structured summary: account, timestamp, `reason_code`, `tried` / `went_wrong` / `why_blocks` / `how_to_fix`.
- **`debug.log`** — verbose companion. Raw MCP error responses, tool names, HTTP statuses, error classes. Token-shaped strings redacted before write.

The wrapper mints a `session_id` UUID on launch and exports it so entries in the two logs are joinable — `jq 'select(.session_id == "...")'` across both files gets you the full trail for one refusal.

## Review queries (documented in the README)

```bash
# recent refusals
jq -c . ~/.local/state/impersonate-audit/refusals.log | tail

# refusals for one account
jq -c 'select(.account == "acme-inc")' ~/.local/state/impersonate-audit/refusals.log

# count by reason
jq -r .reason_code ~/.local/state/impersonate-audit/refusals.log | sort | uniq -c | sort -rn

# full raw-error trail for the most recent auth-expired refusal
SID="$(jq -r 'select(.reason_code == "mcp_auth_expired") | .session_id' \
       ~/.local/state/impersonate-audit/refusals.log | tail -1)"
jq -c "select(.session_id == \"$SID\")" ~/.local/state/impersonate-audit/debug.log
```

## Test plan

- [x] Wrapper mints a session UUID, exports both env vars, creates both log dirs
- [x] Banner shows session_id + both log paths on launch
- [x] Simulated Claude writes valid JSONL to both logs from the SKILL.md jq specs
- [x] Cross-reference query pulls the debug entries for a given refusal by session_id
- [x] `$XDG_STATE_HOME` override works
- [x] `uuidgen` fallback via `/dev/urandom` when uuidgen isn't available