### PR TITLE
fix(ci): make omnibus sync reviewer request non-fatal, point at team-self-driving

### DIFF
--- a/.github/workflows/sync-omnibus.yml
+++ b/.github/workflows/sync-omnibus.yml
@@ -146,6 +146,14 @@ jobs:
             --base "$BASE_REF" \
             --head "$HEAD_REF" \
             --title "$COMMIT_MESSAGE" \
-            --body "Automated skill sync from PostHog release and context-mill." \
-            --reviewer "PostHog/team-posthog-ai")
+            --body "Automated skill sync from PostHog release and context-mill.")
+
+          # Request review separately and non-fatally. A reviewer that no
+          # longer resolves must NOT take down the auto-merge: that is exactly
+          # how the sync silently broke from 2026-06-03 to 2026-08-26 (team
+          # 'team-posthog-ai' was renamed, `gh pr create --reviewer` hard-failed
+          # after creating the PR, and ~70 sync PRs piled up unmerged).
+          gh pr edit "$PR_URL" --add-reviewer "PostHog/team-posthog-desktop" \
+            || echo "::warning::Could not request review from PostHog/team-posthog-desktop; continuing to auto-merge"
+
           gh pr merge "$PR_URL" --auto --squash

--- a/.github/workflows/sync-omnibus.yml
+++ b/.github/workflows/sync-omnibus.yml
@@ -148,8 +148,6 @@ jobs:
             --title "$COMMIT_MESSAGE" \
             --body "Automated skill sync from PostHog release and context-mill.")
 
-          # The review request is deliberately non-fatal: a renamed team must
-          # never block auto-merge again. See PR description for the incident.
           gh pr edit "$PR_URL" --add-reviewer "PostHog/team-posthog-desktop" \
             || echo "::warning::Could not request review from PostHog/team-posthog-desktop; continuing to auto-merge"
 

--- a/.github/workflows/sync-omnibus.yml
+++ b/.github/workflows/sync-omnibus.yml
@@ -148,7 +148,7 @@ jobs:
             --title "$COMMIT_MESSAGE" \
             --body "Automated skill sync from PostHog release and context-mill.")
 
-          gh pr edit "$PR_URL" --add-reviewer "PostHog/team-posthog-desktop" \
-            || echo "::warning::Could not request review from PostHog/team-posthog-desktop; continuing to auto-merge"
+          gh pr edit "$PR_URL" --add-reviewer "PostHog/team-self-driving" \
+            || echo "::warning::Could not request review from PostHog/team-self-driving; continuing to auto-merge"
 
           gh pr merge "$PR_URL" --auto --squash

--- a/.github/workflows/sync-omnibus.yml
+++ b/.github/workflows/sync-omnibus.yml
@@ -148,7 +148,7 @@ jobs:
             --title "$COMMIT_MESSAGE" \
             --body "Automated skill sync from PostHog release and context-mill.")
 
-          gh pr edit "$PR_URL" --add-reviewer "PostHog/team-self-driving" \
-            || echo "::warning::Could not request review from PostHog/team-self-driving; continuing to auto-merge"
+          gh pr edit "$PR_URL" --add-reviewer "PostHog/team-posthog-desktop" --add-reviewer "PostHog/team-self-driving" \
+            || echo "::warning::Could not request reviews; continuing to auto-merge"
 
           gh pr merge "$PR_URL" --auto --squash

--- a/.github/workflows/sync-omnibus.yml
+++ b/.github/workflows/sync-omnibus.yml
@@ -148,7 +148,7 @@ jobs:
             --title "$COMMIT_MESSAGE" \
             --body "Automated skill sync from PostHog release and context-mill.")
 
-          gh pr edit "$PR_URL" --add-reviewer "PostHog/team-posthog-desktop" --add-reviewer "PostHog/team-self-driving" \
-            || echo "::warning::Could not request reviews; continuing to auto-merge"
+          gh pr edit "$PR_URL" --add-reviewer "PostHog/team-self-driving" \
+            || echo "::warning::Could not request review from PostHog/team-self-driving; continuing to auto-merge"
 
           gh pr merge "$PR_URL" --auto --squash

--- a/.github/workflows/sync-omnibus.yml
+++ b/.github/workflows/sync-omnibus.yml
@@ -148,11 +148,8 @@ jobs:
             --title "$COMMIT_MESSAGE" \
             --body "Automated skill sync from PostHog release and context-mill.")
 
-          # Request review separately and non-fatally. A reviewer that no
-          # longer resolves must NOT take down the auto-merge: that is exactly
-          # how the sync silently broke from 2026-06-03 to 2026-08-26 (team
-          # 'team-posthog-ai' was renamed, `gh pr create --reviewer` hard-failed
-          # after creating the PR, and ~70 sync PRs piled up unmerged).
+          # The review request is deliberately non-fatal: a renamed team must
+          # never block auto-merge again. See PR description for the incident.
           gh pr edit "$PR_URL" --add-reviewer "PostHog/team-posthog-desktop" \
             || echo "::warning::Could not request review from PostHog/team-posthog-desktop; continuing to auto-merge"
 


### PR DESCRIPTION
The `--reviewer "PostHog/team-posthog-ai"` argument has hard-failed every run since 2026-06-03 (team was renamed; slug no longer resolves). The PR gets created but `gh pr merge --auto` never runs — hence 73 unmerged sync PRs and a ~3-month-stale `skills/omnibus/`.

Fix: create the PR without a reviewer, request review non-fatally from `PostHog/team-self-driving`, always auto-merge. Sibling fix: PostHog/ai-plugin#203.
